### PR TITLE
[FEAT] 일정 단일 및 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/dh/ondot/member/api/AuthController.java
+++ b/src/main/java/com/dh/ondot/member/api/AuthController.java
@@ -1,6 +1,7 @@
 package com.dh.ondot.member.api;
 
 import com.dh.ondot.member.api.response.AccessToken;
+import com.dh.ondot.member.api.response.LoginResponse;
 import com.dh.ondot.member.api.swagger.AuthSwagger;
 import com.dh.ondot.member.app.dto.Token;
 import com.dh.ondot.member.app.AuthFacade;
@@ -23,7 +24,7 @@ public class AuthController implements AuthSwagger {
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/login/oauth")
-    public Token loginWithOAuth(
+    public LoginResponse loginWithOAuth(
             @RequestParam("provider") OauthProvider oauthProvider,
             @RequestParam("access_token") String accessToken
     ) {

--- a/src/main/java/com/dh/ondot/member/api/response/LoginResponse.java
+++ b/src/main/java/com/dh/ondot/member/api/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.dh.ondot.member.api.response;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isOnboardingCompleted
+) {
+    public static LoginResponse of(String accessToken, String refreshToken, boolean isOnboardingCompleted) {
+        return new LoginResponse(accessToken, refreshToken, isOnboardingCompleted);
+    }
+}

--- a/src/main/java/com/dh/ondot/member/api/swagger/AuthSwagger.java
+++ b/src/main/java/com/dh/ondot/member/api/swagger/AuthSwagger.java
@@ -2,6 +2,7 @@ package com.dh.ondot.member.api.swagger;
 
 import com.dh.ondot.core.domain.ErrorResponse;
 import com.dh.ondot.member.api.response.AccessToken;
+import com.dh.ondot.member.api.response.LoginResponse;
 import com.dh.ondot.member.app.dto.Token;
 import com.dh.ondot.member.domain.enums.OauthProvider;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,12 +43,13 @@ public interface AuthSwagger {
                             responseCode = "200",
                             description = "로그인 성공",
                             content = @Content(
-                                    schema = @Schema(implementation = Token.class),
+                                    schema = @Schema(implementation = LoginResponse.class),
                                     examples = @ExampleObject(
                                             value = """
                         {
                           "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
                           "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                          "isOnboardingCompleted": false
                         }"""
                                     )
                             )
@@ -83,7 +85,7 @@ public interface AuthSwagger {
             }
     )
     @PostMapping("/login/oauth")
-    Token loginWithOAuth(
+    LoginResponse loginWithOAuth(
             @Parameter(description = "OAuth 제공자", example = "KAKAO", required = true)
             @RequestParam("provider") OauthProvider provider,
             @Parameter(description = "소셜 Access Token", required = true)

--- a/src/main/java/com/dh/ondot/member/api/swagger/AuthSwagger.java
+++ b/src/main/java/com/dh/ondot/member/api/swagger/AuthSwagger.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(
         name = "Auth API",
         description = """
-        인증 관련 API입니다.<br><br>
+        <b>인증 관련 API입니다.</b><br><br>
         <b>로그인 후 이용하는 API에서 발생 가능한 토큰 오류</b><br>
         • <code>TOKEN_MISSING</code> : Authorization 헤더 없음<br>
         • <code>INVALID_TOKEN_HEADER</code>: "Bearer " 접두사 누락<br>

--- a/src/main/java/com/dh/ondot/member/app/AuthFacade.java
+++ b/src/main/java/com/dh/ondot/member/app/AuthFacade.java
@@ -28,7 +28,7 @@ public class AuthFacade {
                 .orElseGet(() -> registerMemberWithOauth(userInfo, oauthProvider));
 
         Token token = tokenFacade.issue(member.getId());
-        boolean isOnboardingCompleted = member.getPreparationTime() != null;
+        boolean isOnboardingCompleted = member.checkOnboardingCompleted();
 
         return LoginResponse.of(token.accessToken(),token.refreshToken(),isOnboardingCompleted);
     }

--- a/src/main/java/com/dh/ondot/member/app/AuthFacade.java
+++ b/src/main/java/com/dh/ondot/member/app/AuthFacade.java
@@ -1,5 +1,6 @@
 package com.dh.ondot.member.app;
 
+import com.dh.ondot.member.api.response.LoginResponse;
 import com.dh.ondot.member.app.dto.Token;
 import com.dh.ondot.member.domain.*;
 import com.dh.ondot.member.domain.dto.UserInfo;
@@ -19,14 +20,17 @@ public class AuthFacade {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Token loginWithOAuth(OauthProvider oauthProvider, String accessToken) {
+    public LoginResponse loginWithOAuth(OauthProvider oauthProvider, String accessToken) {
         OauthApi oauthApi = oauthApiFactory.getOauthApi(oauthProvider);
         UserInfo userInfo = oauthApi.fetchUser(accessToken);
 
         Member member = memberRepository.findByOauthInfo(OauthInfo.of(oauthProvider, userInfo.oauthProviderId()))
                 .orElseGet(() -> registerMemberWithOauth(userInfo, oauthProvider));
 
-        return tokenFacade.issue(member.getId());
+        Token token = tokenFacade.issue(member.getId());
+        boolean isOnboardingCompleted = member.getPreparationTime() != null;
+
+        return LoginResponse.of(token.accessToken(),token.refreshToken(),isOnboardingCompleted);
     }
 
     private Member registerMemberWithOauth(UserInfo userInfo, OauthProvider oauthProvider) {

--- a/src/main/java/com/dh/ondot/member/domain/Member.java
+++ b/src/main/java/com/dh/ondot/member/domain/Member.java
@@ -66,4 +66,8 @@ public class Member extends BaseTimeEntity {
     public void updateMapProvider(String mapProvider) {
         this.mapProvider = MapProvider.from(mapProvider);
     }
+
+    public boolean checkOnboardingCompleted() {
+        return preparationTime != null;
+    }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
+++ b/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
@@ -47,6 +47,7 @@ public class ScheduleController implements ScheduleSwagger {
         scheduleFacade.createVoiceSchedule(memberId, request);
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{scheduleId}")
     public ScheduleDetailResponse getSchedule(
             @RequestAttribute("memberId") Long memberId,

--- a/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
+++ b/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
@@ -4,13 +4,18 @@ import com.dh.ondot.schedule.api.request.ScheduleCreateRequest;
 import com.dh.ondot.schedule.api.request.ScheduleUpdateRequest;
 import com.dh.ondot.schedule.api.request.VoiceScheduleCreateRequest;
 import com.dh.ondot.schedule.api.response.ScheduleCreateResponse;
+import com.dh.ondot.schedule.api.response.ScheduleDetailResponse;
+import com.dh.ondot.schedule.api.response.HomeScheduleListResponse;
 import com.dh.ondot.schedule.api.response.ScheduleUpdateResponse;
 import com.dh.ondot.schedule.api.swagger.ScheduleSwagger;
 import com.dh.ondot.schedule.app.ScheduleFacade;
+import com.dh.ondot.schedule.app.ScheduleQueryFacade;
 import com.dh.ondot.schedule.app.dto.UpdateScheduleResult;
 import com.dh.ondot.schedule.domain.Schedule;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/schedules")
 public class ScheduleController implements ScheduleSwagger {
+    private final ScheduleQueryFacade scheduleQueryFacade;
     private final ScheduleFacade scheduleFacade;
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -41,6 +47,28 @@ public class ScheduleController implements ScheduleSwagger {
         scheduleFacade.createVoiceSchedule(memberId, request);
     }
 
+    @GetMapping("/{scheduleId}")
+    public ScheduleDetailResponse getSchedule(
+            @RequestAttribute("memberId") Long memberId,
+            @PathVariable Long scheduleId
+    ) {
+        Schedule schedule = scheduleQueryFacade.findOne(memberId, scheduleId);
+
+        return ScheduleDetailResponse.from(schedule);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    public HomeScheduleListResponse getSchedules(
+            @RequestAttribute("memberId") Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return scheduleQueryFacade.findAll(memberId, pageable);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{scheduleId}")
     public ResponseEntity<ScheduleUpdateResponse> updateSchedule(
             @RequestAttribute("memberId") Long memberId,

--- a/src/main/java/com/dh/ondot/schedule/api/request/PlaceDto.java
+++ b/src/main/java/com/dh/ondot/schedule/api/request/PlaceDto.java
@@ -1,5 +1,6 @@
 package com.dh.ondot.schedule.api.request;
 
+import com.dh.ondot.schedule.domain.Place;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -14,4 +15,7 @@ public record PlaceDto(
 
         @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double latitude
 ) {
+    public static PlaceDto from(Place place) {
+        return new PlaceDto(place.getTitle(), place.getRoadAddress(), place.getLongitude(), place.getLatitude());
+    }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/dh/ondot/schedule/api/request/ScheduleCreateRequest.java
@@ -32,7 +32,7 @@ public record ScheduleCreateRequest(
 
             @NotNull LocalTime triggeredAt,
 
-            @NotBlank String mission,
+//            @NotBlank String mission,
 
             @NotNull Boolean isSnoozeEnabled,
 

--- a/src/main/java/com/dh/ondot/schedule/api/response/AlarmDto.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/AlarmDto.java
@@ -1,0 +1,32 @@
+package com.dh.ondot.schedule.api.response;
+
+import com.dh.ondot.schedule.domain.Alarm;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public record AlarmDto(
+        String alarmMode,
+        boolean isEnabled,
+        LocalDateTime triggeredAt,
+        boolean isSnoozeEnabled,
+        Integer snoozeInterval,
+        Integer snoozeCount,
+        String soundCategory,
+        String ringTone,
+        Integer volume
+) {
+    public static AlarmDto of(Alarm alarm) {
+        return new AlarmDto(
+                alarm.getMode().name(),
+                alarm.isEnabled(),
+                alarm.getTriggeredAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                alarm.getSnooze().isSnoozeEnabled(),
+                alarm.getSnooze().getSnoozeInterval().getValue(),
+                alarm.getSnooze().getSnoozeCount().getValue(),
+                alarm.getSound().getSoundCategory().name(),
+                alarm.getSound().getRingTone().name(),
+                alarm.getSound().getVolume()
+        );
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/api/response/HomeScheduleListResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/HomeScheduleListResponse.java
@@ -1,0 +1,20 @@
+package com.dh.ondot.schedule.api.response;
+
+import com.dh.ondot.schedule.app.dto.HomeScheduleListItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record HomeScheduleListResponse(
+        LocalDateTime earliestAlarmTime,
+        List<HomeScheduleListItem> scheduleList,
+        boolean hasNext
+) {
+    public static HomeScheduleListResponse of(LocalDateTime earliest, List<HomeScheduleListItem> list, boolean hasNext) {
+        return new HomeScheduleListResponse(
+                earliest,
+                list,
+                hasNext
+        );
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/api/response/HomeScheduleListResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/HomeScheduleListResponse.java
@@ -6,12 +6,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record HomeScheduleListResponse(
+        boolean isOnboardingCompleted,
         LocalDateTime earliestAlarmTime,
         List<HomeScheduleListItem> scheduleList,
         boolean hasNext
 ) {
-    public static HomeScheduleListResponse of(LocalDateTime earliest, List<HomeScheduleListItem> list, boolean hasNext) {
+    public static HomeScheduleListResponse of(boolean isOnboardingCompleted, LocalDateTime earliest, List<HomeScheduleListItem> list, boolean hasNext) {
         return new HomeScheduleListResponse(
+                isOnboardingCompleted,
                 earliest,
                 list,
                 hasNext

--- a/src/main/java/com/dh/ondot/schedule/api/response/LatestAlarmResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/LatestAlarmResponse.java
@@ -2,8 +2,6 @@ package com.dh.ondot.schedule.api.response;
 
 import com.dh.ondot.schedule.domain.Alarm;
 
-import java.time.LocalDateTime;
-
 public record LatestAlarmResponse(
         AlarmDto preparationAlarm,
         AlarmDto departureAlarm
@@ -13,31 +11,5 @@ public record LatestAlarmResponse(
                 AlarmDto.of(preparation),
                 AlarmDto.of(departure)
         );
-    }
-
-    public record AlarmDto(
-            String alarmMode,
-            boolean isEnabled,
-            LocalDateTime triggeredAt,
-            boolean isSnoozeEnabled,
-            Integer snoozeInterval,
-            Integer snoozeCount,
-            String soundCategory,
-            String ringTone,
-            Integer volume
-    ) {
-        public static AlarmDto of(Alarm alarm) {
-            return new AlarmDto(
-                    alarm.getMode().name(),
-                    alarm.isEnabled(),
-                    alarm.getTriggeredAt(),
-                    alarm.getSnooze().isSnoozeEnabled(),
-                    alarm.getSnooze().getSnoozeInterval().getValue(),
-                    alarm.getSnooze().getSnoozeCount().getValue(),
-                    alarm.getSound().getSoundCategory().name(),
-                    alarm.getSound().getRingTone().name(),
-                    alarm.getSound().getVolume()
-            );
-        }
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleDetailResponse.java
@@ -1,0 +1,32 @@
+package com.dh.ondot.schedule.api.response;
+
+import com.dh.ondot.schedule.api.request.PlaceDto;
+import com.dh.ondot.schedule.domain.Schedule;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+public record ScheduleDetailResponse(
+        Long          scheduleId,
+        String        title,
+        boolean       isRepeat,
+        List<Integer> repeatDays,
+        LocalDateTime appointmentAt,
+        AlarmDto preparationAlarm,
+        AlarmDto departureAlarm,
+        PlaceDto departurePlace,
+        PlaceDto      arrivalPlace
+) {
+    public static ScheduleDetailResponse from(Schedule s) {
+        return new ScheduleDetailResponse(
+                s.getId(), s.getTitle(), s.getIsRepeat(),
+                s.getRepeatDays() == null ? List.of() : List.copyOf(s.getRepeatDays()),
+                s.getAppointmentAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                AlarmDto.of(s.getPreparationAlarm()),
+                AlarmDto.of(s.getDepartureAlarm()),
+                PlaceDto.from(s.getDeparturePlace()),
+                PlaceDto.from(s.getArrivalPlace())
+        );
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/PlaceSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/PlaceSwagger.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Tag(
         name = "Place API",
         description = """
-        <p><b>장소(Place) 검색·최근 기록</b> 기능을 제공합니다.</p>
+        <p><b>장소(Place)</b> 관련 API입니다.</p>
         """
 )
 @RequestMapping("/places")

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -293,6 +293,7 @@ public interface ScheduleSwagger {
                                     schema    = @Schema(implementation = HomeScheduleListResponse.class),
                                     examples  = @ExampleObject(value = """
                     {
+                      "isOnboardingCompleted": true,
                       "earliestAlarmAt": "2025-05-10T18:30:00",
                       "hasNext": false,
                       "scheduleList": [

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -384,7 +384,7 @@ public interface ScheduleSwagger {
                         "alarmMode": "SOUND",
                         "triggeredAt": "2025-05-10T19:10:00",
                         "isSnoozeEnabled": false,
-                        "snoozeInterval": 0,
+                        "snoozeInterval": 1,
                         "snoozeCount": -1,
                         "soundCategory": "DEFAULT",
                         "ringTone": "DEFAULT",

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -80,7 +80,7 @@ public interface ScheduleSwagger {
                       "preparationAlarm": {
                         "alarmMode": "VIBRATE",
                         "isEnabled": true,
-                        "triggeredAt": "18:30:00",
+                        "triggeredAt": "2025-05-10T18:30:00",
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
@@ -90,7 +90,7 @@ public interface ScheduleSwagger {
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
-                        "triggeredAt": "18:50:00",
+                        "triggeredAt": "2025-05-10T18:50:00",
                         "isSnoozeEnabled": false,
                         "snoozeInterval": 1,
                         "snoozeCount": -1,
@@ -209,7 +209,7 @@ public interface ScheduleSwagger {
                       "preparationAlarm": {
                         "alarmMode": "VIBRATE",
                         "isEnabled": true,
-                        "triggeredAt": "18:30:00",
+                        "triggeredAt": "2025-05-10T18:30:00",
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
@@ -219,7 +219,7 @@ public interface ScheduleSwagger {
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
-                        "triggeredAt": "18:50:00",
+                        "triggeredAt": "2025-05-10T18:50:00",
                         "isSnoozeEnabled": false,
                         "snoozeInterval": 1,
                         "snoozeCount": -1,
@@ -371,7 +371,7 @@ public interface ScheduleSwagger {
                       "preparationAlarm": {
                         "alarmMode": "VIBRATE",
                         "isEnabled": true,
-                        "triggeredAt": "18:45:00",
+                        "triggeredAt": "2025-05-10T18:45:00",
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
@@ -381,7 +381,7 @@ public interface ScheduleSwagger {
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
-                        "triggeredAt": "19:10:00",
+                        "triggeredAt": "2025-05-10T19:10:00",
                         "isSnoozeEnabled": false,
                         "snoozeInterval": 0,
                         "snoozeCount": -1,

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -29,8 +29,8 @@ import org.springframework.web.bind.annotation.*;
         • <code>AlarmMode</code>: SILENT, VIBRATE, SOUND<br>
         • <code>SnoozeInterval</code>: 1, 3, 5, 10, 30, 60 (분)<br>
         • <code>SnoozeCount</code>: -1(INFINITE), 1, 3, 5, 10 (회)<br>
-        • <code>SoundCategory</code>: <i>BIRD, OCEAN, DEFAULT …</i><br>
-        • <code>RingTone</code>: <i>beep.mp3, morning.mp3 …</i>
+        • <code>SoundCategory</code>: <i>DEFAULT …</i><br>
+        • <code>RingTone</code>: <i>DEFAULT …</i>
         """
 )
 @RequestMapping("/schedules")
@@ -75,22 +75,21 @@ public interface ScheduleSwagger {
                         "alarmMode": "VIBRATE",
                         "isEnabled": true,
                         "triggeredAt": "18:30:00",
-                        "mission": "QR",
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
-                        "soundCategory": "BIRD",
-                        "ringTone": "morning.mp3",
+                        "soundCategory": "DEFAULT",
+                        "ringTone": "DEFAULT",
                         "volume": 7
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
                         "triggeredAt": "18:50:00",
                         "isSnoozeEnabled": false,
-                        "snoozeInterval": 0,
+                        "snoozeInterval": 1,
                         "snoozeCount": -1,
                         "soundCategory": "DEFAULT",
-                        "ringTone": "beep.mp3",
+                        "ringTone": "DEFAULT",
                         "volume": 8
                       }
                     }"""
@@ -202,12 +201,11 @@ public interface ScheduleSwagger {
                         "alarmMode": "VIBRATE",
                         "isEnabled": true,
                         "triggeredAt": "18:45:00",
-                        "mission": "QR",
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
-                        "soundCategory": "BIRD",
-                        "ringTone": "morning.mp3",
+                        "soundCategory": "DEFAULT",
+                        "ringTone": "DEFAULT",
                         "volume": 7
                       },
                       "departureAlarm": {
@@ -217,7 +215,7 @@ public interface ScheduleSwagger {
                         "snoozeInterval": 0,
                         "snoozeCount": -1,
                         "soundCategory": "DEFAULT",
-                        "ringTone": "beep.mp3",
+                        "ringTone": "DEFAULT",
                         "volume": 8
                       }
                     }"""

--- a/src/main/java/com/dh/ondot/schedule/app/AlarmFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/AlarmFacade.java
@@ -5,14 +5,12 @@ import com.dh.ondot.schedule.core.exception.NotFoundScheduleException;
 import com.dh.ondot.schedule.domain.Schedule;
 import com.dh.ondot.schedule.domain.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AlarmFacade {
-
     private final MemberService memberService;
     private final ScheduleRepository scheduleRepository;
 
@@ -21,7 +19,7 @@ public class AlarmFacade {
         memberService.findExistingMember(memberId);
 
         return scheduleRepository
-                .findLatestByMemberId(memberId)
+                .findLatestScheduleByMemberId(memberId)
                 .orElseThrow(() -> new NotFoundScheduleException(memberId));
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/app/ScheduleFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ScheduleFacade.java
@@ -40,7 +40,7 @@ public class ScheduleFacade {
                 request.preparationAlarm().alarmMode(),
                 request.preparationAlarm().isEnabled(),
                 request.appointmentAt().toLocalDate().atTime(request.preparationAlarm().triggeredAt()),
-                request.preparationAlarm().mission(),
+//                request.preparationAlarm().mission(),
                 request.preparationAlarm().isSnoozeEnabled(),
                 request.preparationAlarm().snoozeInterval(),
                 request.preparationAlarm().snoozeCount(),
@@ -137,7 +137,7 @@ public class ScheduleFacade {
                 request.preparationAlarm().isEnabled(),
                 request.appointmentAt().toLocalDate()
                         .atTime(request.preparationAlarm().triggeredAt()),
-                request.preparationAlarm().mission(),
+//                request.preparationAlarm().mission(),
                 request.preparationAlarm().isSnoozeEnabled(),
                 request.preparationAlarm().snoozeInterval(),
                 request.preparationAlarm().snoozeCount(),
@@ -162,6 +162,7 @@ public class ScheduleFacade {
                 new TreeSet<>(request.repeatDays()),
                 request.appointmentAt()
         );
+        // todo: nextAlarmAt 업데이트 로직 추가
 
         return new UpdateScheduleResult(schedule, placeChanged || timeChanged);
     }

--- a/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
@@ -46,7 +46,7 @@ public class ScheduleQueryFacade {
                 .findFirst()
                 .orElse(null);
 
-        boolean isOnboardingCompleted = member.getPreparationTime() != null;
+        boolean isOnboardingCompleted = member.checkOnboardingCompleted();
 
         return HomeScheduleListResponse.of(isOnboardingCompleted, earliest, homeScheduleListItem, slice.hasNext());
     }

--- a/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
@@ -1,5 +1,6 @@
 package com.dh.ondot.schedule.app;
 
+import com.dh.ondot.member.domain.Member;
 import com.dh.ondot.member.domain.service.MemberService;
 import com.dh.ondot.schedule.api.response.*;
 import com.dh.ondot.schedule.app.dto.HomeScheduleListItem;
@@ -30,6 +31,7 @@ public class ScheduleQueryFacade {
     }
 
     public HomeScheduleListResponse findAll(Long memberId, Pageable page) {
+        Member member = memberService.findExistingMember(memberId);
         Slice<Schedule> slice =  scheduleQueryRepository.findPageByMember(memberId, page);
 
         List<HomeScheduleListItem> homeScheduleListItem = slice.getContent().stream()
@@ -44,6 +46,8 @@ public class ScheduleQueryFacade {
                 .findFirst()
                 .orElse(null);
 
-        return HomeScheduleListResponse.of(earliest, homeScheduleListItem, slice.hasNext());
+        boolean isOnboardingCompleted = member.getPreparationTime() != null;
+
+        return HomeScheduleListResponse.of(isOnboardingCompleted, earliest, homeScheduleListItem, slice.hasNext());
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/app/dto/HomeScheduleListItem.java
+++ b/src/main/java/com/dh/ondot/schedule/app/dto/HomeScheduleListItem.java
@@ -1,0 +1,30 @@
+package com.dh.ondot.schedule.app.dto;
+
+import com.dh.ondot.schedule.domain.Schedule;
+
+import java.time.*;
+import java.util.List;
+
+public record HomeScheduleListItem(
+        Long scheduleId,
+        String scheduleTitle,
+        boolean isRepeat,
+        List<Integer> repeatDays,
+        LocalDateTime appointmentAt,
+        LocalDateTime nextAlarmAt,
+        LocalDateTime preparationTriggeredAt,
+        LocalDateTime departureTriggeredAt,
+        boolean isEnabled
+) {
+    public static HomeScheduleListItem from(Schedule schedule) {
+        return new HomeScheduleListItem(
+                schedule.getId(), schedule.getTitle(), schedule.getIsRepeat(),
+                schedule.getRepeatDays() == null ? List.of() : List.copyOf(schedule.getRepeatDays()),
+                schedule.getAppointmentAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                schedule.getNextAlarmAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                schedule.getPreparationAlarm().getTriggeredAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                schedule.getDepartureAlarm().getTriggeredAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                schedule.getDepartureAlarm().isEnabled()
+        );
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/domain/Alarm.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/Alarm.java
@@ -2,13 +2,14 @@ package com.dh.ondot.schedule.domain;
 
 import com.dh.ondot.core.domain.BaseTimeEntity;
 import com.dh.ondot.schedule.domain.enums.AlarmMode;
-import com.dh.ondot.schedule.domain.enums.Mission;
 import com.dh.ondot.schedule.domain.vo.Snooze;
 import com.dh.ondot.schedule.domain.vo.Sound;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Entity
 @Getter
@@ -30,11 +31,11 @@ public class Alarm extends BaseTimeEntity {
     private boolean isEnabled;
 
     @Column(name = "triggered_at", nullable = false)
-    private LocalDateTime triggeredAt;
+    private Instant triggeredAt;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "mission")
-    private Mission mission;
+//    @Enumerated(EnumType.STRING)
+//    @Column(name = "mission")
+//    private Mission mission;
 
     @Embedded
     private Snooze snooze;
@@ -42,14 +43,14 @@ public class Alarm extends BaseTimeEntity {
     @Embedded
     private Sound sound;
 
-    public static Alarm createPreparationAlarm(String alarmMode, boolean isEnabled, LocalDateTime triggeredAt, String mission,
+    public static Alarm createPreparationAlarm(String alarmMode, boolean isEnabled, LocalDateTime triggeredAt,
                                                boolean isSnoozeEnabled, Integer snoozeInterval, Integer snoozeCount,
                                                String soundCategory, String ringTone, Integer volume) {
         return Alarm.builder()
                 .mode(AlarmMode.from(alarmMode))
                 .isEnabled(isEnabled)
-                .triggeredAt(triggeredAt)
-                .mission(Mission.from(mission))
+                .triggeredAt(triggeredAt.atZone(ZoneId.of("Asia/Seoul")).toInstant())
+//                .mission(Mission.from(mission))
                 .snooze(Snooze.of(isSnoozeEnabled, snoozeInterval, snoozeCount))
                 .sound(Sound.of(soundCategory, ringTone, volume))
                 .build();
@@ -61,21 +62,21 @@ public class Alarm extends BaseTimeEntity {
         return Alarm.builder()
                 .mode(AlarmMode.from(alarmMode))
                 .isEnabled(true)
-                .triggeredAt(triggeredAt)
+                .triggeredAt(triggeredAt.atZone(ZoneId.of("Asia/Seoul")).toInstant())
                 .snooze(Snooze.of(isSnoozeEnabled, snoozeInterval, snoozeCount))
                 .sound(Sound.of(soundCategory, ringTone, volume))
                 .build();
     }
 
     public void updatePreparation(String alarmMode, boolean isEnabled,
-                                  LocalDateTime triggeredAt, String mission,
+                                  LocalDateTime triggeredAt,
                                   boolean isSnoozeEnabled, Integer snoozeInterval, Integer snoozeCount,
                                   String soundCategory, String ringTone, Integer volume
     ) {
         this.mode          = AlarmMode.from(alarmMode);
         this.isEnabled     = isEnabled;
-        this.triggeredAt   = triggeredAt;
-        this.mission       = Mission.from(mission);
+        this.triggeredAt   = triggeredAt.atZone(ZoneId.of("Asia/Seoul")).toInstant();
+//        this.mission       = Mission.from(mission);
         this.snooze        = Snooze.of(isSnoozeEnabled, snoozeInterval, snoozeCount);
         this.sound         = Sound.of(soundCategory, ringTone, volume);
     }

--- a/src/main/java/com/dh/ondot/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/repository/ScheduleRepository.java
@@ -1,12 +1,10 @@
 package com.dh.ondot.schedule.domain.repository;
 
 import com.dh.ondot.schedule.domain.Schedule;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -14,10 +12,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         select *
         from schedules s
         join alarms p on s.preparation_alarm_id = p.alarm_id
-        join alarms d on s.departure_alarm_id   = d.alarm_id
+        join alarms d on s.departure_alarm_id = d.alarm_id
         where s.member_id = :memberId
         order by s.updated_at desc
         limit 1
     """)
-    Optional<Schedule> findLatestByMemberId(@Param("memberId") Long memberId);
+    Optional<Schedule> findLatestScheduleByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
@@ -1,0 +1,54 @@
+package com.dh.ondot.schedule.infra;
+
+import com.dh.ondot.schedule.domain.QAlarm;
+import com.dh.ondot.schedule.domain.QPlace;
+import com.dh.ondot.schedule.domain.QSchedule;
+import com.dh.ondot.schedule.domain.Schedule;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ScheduleQueryRepository {
+    private final JPAQueryFactory q;
+
+    private static final QSchedule s  = QSchedule.schedule;
+    private static final QAlarm pa = new QAlarm("pa");// preparationAlarm
+    private static final QAlarm da = new QAlarm("da");// departureAlarm
+    private static final QPlace dp = new QPlace("dp");// departurePlace
+    private static final QPlace ap = new QPlace("ap");// arrivalPlace
+
+    public Optional<Schedule> findScheduleByMemberIdAndId(Long memberId, Long scheduleId) {
+        Schedule result = q.selectFrom(s)
+                .join(s.preparationAlarm, pa).fetchJoin()
+                .join(s.departureAlarm, da).fetchJoin()
+                .join(s.departurePlace, dp).fetchJoin()
+                .join(s.arrivalPlace, ap).fetchJoin()
+                .where(s.id.eq(scheduleId), s.memberId.eq(memberId))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    public Slice<Schedule> findPageByMember(Long memberId, Pageable pageable) {
+        List<Schedule> content = q.selectFrom(s)
+                .join(s.preparationAlarm, pa).fetchJoin()
+                .join(s.departureAlarm, da).fetchJoin()
+                .where(s.memberId.eq(memberId))
+                .orderBy(s.nextAlarmAt.asc(), s.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) content.remove(content.size() - 1);
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+}


### PR DESCRIPTION
## Issue Number
#17 

## As-Is
<!-- 문제 상황 정의 -->
일정 단일 및 전체 조회 기능을 구현합니다

## To-Be
<!-- 변경 사항 -->
- [x] 일정 단일 조회 API
- [x] 일정 전체 조회 API
  - [x] 페이징 처리
- [x] QueryDSL을 통한 조회 쿼리 구현
- [x] Swagger 명세 작성
- [x] Schedule 테이블 nextAlarmAt 컬럼 추가
- [x] 온보딩 및 일정 전체 조회 응답값으로 온보딩 여부 추가

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 단일 스케줄 상세 조회 및 스케줄 목록(페이지네이션, 무한 스크롤 지원) API가 추가되었습니다.
  - 스케줄 상세, 홈 스케줄 리스트, 알람 정보 응답 객체가 도입되었습니다.
  - 스케줄의 다음 알람 시간 계산 및 노출 기능이 도입되었습니다.
  - 로그인 응답에 온보딩 완료 여부가 포함되었습니다.

- **버그 수정**
  - 알람 및 스케줄의 시간 필드가 Instant 기반으로 개선되어 시간대 일관성이 향상되었습니다.

- **문서화**
  - Swagger 문서에 신규 스케줄 조회 API가 반영되고, 예시 값 및 설명이 일부 수정되었습니다.
  - 인증 및 장소 관련 API 설명이 간결하게 변경되었습니다.

- **리팩터링**
  - 내부 코드 구조 개선 및 중복 제거, 일부 필드 및 메서드가 주석 처리 또는 이동되었습니다.

- **기타**
  - 미션(mission) 필드 및 관련 기능이 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->