### PR TITLE
[FEAT] STT 일정 텍스트 파싱 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // Spring AI
+    implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+    implementation 'org.springframework.ai:spring-ai-openai'
+
     // 스프링부트 3.xx에서는 p6spy 버전 1.9.0 사용해야됨
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
@@ -61,6 +65,23 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
 }
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
+}
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/dh/ondot/core/config/SpringAiConfig.java
+++ b/src/main/java/com/dh/ondot/core/config/SpringAiConfig.java
@@ -1,0 +1,27 @@
+package com.dh.ondot.core.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringAiConfig {
+    @Bean
+    ChatClient chatClient(
+            @Value("${openai.api-key}") String apiKey
+    ) {
+        OpenAiApi openAiApi = OpenAiApi.builder()
+                .apiKey(apiKey)
+                .build();
+
+        ChatModel chatModel = OpenAiChatModel.builder()
+                .openAiApi(openAiApi)
+                .build();
+
+        return ChatClient.create(chatModel);
+    }
+}

--- a/src/main/java/com/dh/ondot/core/domain/BaseTimeEntity.java
+++ b/src/main/java/com/dh/ondot/core/domain/BaseTimeEntity.java
@@ -7,15 +7,15 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 }

--- a/src/main/java/com/dh/ondot/core/domain/ErrorResponse.java
+++ b/src/main/java/com/dh/ondot/core/domain/ErrorResponse.java
@@ -44,6 +44,10 @@ public record ErrorResponse(
         this(e.getErrorCode(), e.getMessage(), null, null);
     }
 
+    public <T extends TooManyRequestsException> ErrorResponse(T e){
+        this(e.getErrorCode(), e.getMessage(), null, null);
+    }
+
     public <T extends InternalServerException> ErrorResponse(T e){
         this(e.getErrorCode(), e.getMessage(), null, null);
     }

--- a/src/main/java/com/dh/ondot/core/domain/ErrorResponse.java
+++ b/src/main/java/com/dh/ondot/core/domain/ErrorResponse.java
@@ -52,6 +52,10 @@ public record ErrorResponse(
         this(e.getErrorCode(), e.getMessage(), null, null);
     }
 
+    public <T extends BadGatewayException> ErrorResponse(T e){
+        this(e.getErrorCode(), e.getMessage(), null, null);
+    }
+
     public <T extends ServiceUnavailableException> ErrorResponse(T e) {
 
         this(e.getErrorCode(), e.getMessage(), null, null);

--- a/src/main/java/com/dh/ondot/core/exception/BadGatewayException.java
+++ b/src/main/java/com/dh/ondot/core/exception/BadGatewayException.java
@@ -1,0 +1,9 @@
+package com.dh.ondot.core.exception;
+
+public abstract class BadGatewayException extends RuntimeException {
+    public BadGatewayException(String message) {
+        super(message);
+    }
+
+    public abstract String getErrorCode();
+}

--- a/src/main/java/com/dh/ondot/core/exception/ErrorCode.java
+++ b/src/main/java/com/dh/ondot/core/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     NO_RESOURCE_FOUND(NOT_FOUND,"요청한 리소스를 찾을 수 없습니다."),
     METHOD_NOT_SUPPORTED(METHOD_NOT_ALLOWED,"허용되지 않은 메서드입니다."),
     MEDIA_TYPE_NOT_SUPPORTED(UNSUPPORTED_MEDIA_TYPE,"허용되지 않은 미디어 타입입니다."),
-    SERVER_ERROR(INTERNAL_SERVER_ERROR,"서버 오류가 발생했습니다. 관리자에게 문의하세요."),
+    SERVER_ERROR(INTERNAL_SERVER_ERROR,"서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
     REDIS_UNAVAILABLE(SERVICE_UNAVAILABLE,"Redis 서버에 연결할 수 없습니다."),
 
     // Token
@@ -60,6 +60,9 @@ public enum ErrorCode {
 
     // AI
     AI_USAGE_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, "오늘 사용 가능한 AI 사용 횟수를 초과했습니다. MemberId : %d, Date : %s"),
+    OPEN_AI_PARSING_ERROR(BAD_REQUEST, "약속 문장을 이해할 수 없습니다. 형식을 확인 후 다시 시도해주세요."),
+    UNAVAILABLE_OPEN_AI_SERVER(BAD_GATEWAY, "일시적으로 Open AI 서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    UNHANDLED_OPEN_AI(INTERNAL_SERVER_ERROR, "Open AI 요청 과정에서 알 수 없는 문제가 발생했습니다. 관리자에게 문의해주세요."),
     ;
 
     public final HttpStatus httpStatus;

--- a/src/main/java/com/dh/ondot/core/exception/ErrorCode.java
+++ b/src/main/java/com/dh/ondot/core/exception/ErrorCode.java
@@ -57,6 +57,9 @@ public enum ErrorCode {
 
     //Place
     PLACE_HISTORY_SERIALIZATION_FAILED(INTERNAL_SERVER_ERROR, "장소 검색 기록 직렬화 중 오류가 발생했습니다."),
+
+    // AI
+    AI_USAGE_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, "오늘 사용 가능한 AI 사용 횟수를 초과했습니다. MemberId : %d, Date : %s"),
     ;
 
     public final HttpStatus httpStatus;

--- a/src/main/java/com/dh/ondot/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dh/ondot/core/exception/GlobalExceptionHandler.java
@@ -150,9 +150,17 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_GATEWAY)
+    public ErrorResponse handleBadGatewayException(BadGatewayException e) {
+        log.error(e.getMessage());
+
+        return new ErrorResponse(e);
+    }
+
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     public ErrorResponse handleServiceUnavailableException(ServiceUnavailableException e) {
-        log.warn(e.getMessage());
+        log.error(e.getMessage());
 
         return new ErrorResponse(e);
     }

--- a/src/main/java/com/dh/ondot/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dh/ondot/core/exception/GlobalExceptionHandler.java
@@ -126,6 +126,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+    public ErrorResponse handleTooManyRequestsException(TooManyRequestsException e) {
+        log.warn(e.getMessage());
+
+        return new ErrorResponse(e);
+    }
+
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleInternalServerErrorException(InternalServerException e) {
         log.error(e.getMessage(), e);

--- a/src/main/java/com/dh/ondot/core/exception/TooManyRequestsException.java
+++ b/src/main/java/com/dh/ondot/core/exception/TooManyRequestsException.java
@@ -1,0 +1,9 @@
+package com.dh.ondot.core.exception;
+
+public abstract class TooManyRequestsException extends RuntimeException {
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+
+    public abstract String getErrorCode();
+}

--- a/src/main/java/com/dh/ondot/core/util/DateTimeUtils.java
+++ b/src/main/java/com/dh/ondot/core/util/DateTimeUtils.java
@@ -15,6 +15,10 @@ public class DateTimeUtils {
         return instant.atZone(DEFAULT_ZONE).toLocalDateTime();
     }
 
+    public static LocalDateTime nowSeoulDateTime() {
+        return LocalDateTime.now(DEFAULT_ZONE);
+    }
+
     public static LocalDate nowSeoulDate() {
         return LocalDate.now(DEFAULT_ZONE);
     }

--- a/src/main/java/com/dh/ondot/core/util/DateTimeUtils.java
+++ b/src/main/java/com/dh/ondot/core/util/DateTimeUtils.java
@@ -1,0 +1,21 @@
+package com.dh.ondot.core.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@UtilityClass
+public class DateTimeUtils {
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
+    public static LocalDateTime toSeoulDateTime(Instant instant) {
+        return instant.atZone(DEFAULT_ZONE).toLocalDateTime();
+    }
+
+    public static LocalDate nowSeoulDate() {
+        return LocalDate.now(DEFAULT_ZONE);
+    }
+}

--- a/src/main/java/com/dh/ondot/member/api/response/OnboardingResponse.java
+++ b/src/main/java/com/dh/ondot/member/api/response/OnboardingResponse.java
@@ -3,12 +3,13 @@ package com.dh.ondot.member.api.response;
 import com.dh.ondot.member.domain.Member;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public record OnboardingResponse(
         Long memberId,
         LocalDateTime updatedAt
 ) {
     public static OnboardingResponse from(Member member) {
-        return new OnboardingResponse(member.getId(), member.getUpdatedAt());
+        return new OnboardingResponse(member.getId(), member.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime());
     }
 }

--- a/src/main/java/com/dh/ondot/member/api/response/UpdateMapProviderResponse.java
+++ b/src/main/java/com/dh/ondot/member/api/response/UpdateMapProviderResponse.java
@@ -3,12 +3,13 @@ package com.dh.ondot.member.api.response;
 import com.dh.ondot.member.domain.Member;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public record UpdateMapProviderResponse(
         Long memberId,
         LocalDateTime updatedAt
 ) {
     public static UpdateMapProviderResponse from(Member member) {
-        return new UpdateMapProviderResponse(member.getId(), member.getUpdatedAt());
+        return new UpdateMapProviderResponse(member.getId(), member.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime());
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
+++ b/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
@@ -47,9 +47,10 @@ public class ScheduleController implements ScheduleSwagger {
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/nlp")
     public ScheduleParsedResponse parse(
+            @RequestAttribute("memberId") Long memberId,
             @Valid @RequestBody ScheduleParsedRequest request
     ) {
-        return parseFacade.parse(request.text());
+        return parseFacade.parse(memberId, request.text());
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/dh/ondot/schedule/api/request/ScheduleParsedRequest.java
+++ b/src/main/java/com/dh/ondot/schedule/api/request/ScheduleParsedRequest.java
@@ -1,0 +1,8 @@
+package com.dh.ondot.schedule.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ScheduleParsedRequest(
+        @NotBlank String text
+) {
+}

--- a/src/main/java/com/dh/ondot/schedule/api/response/AlarmDto.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/AlarmDto.java
@@ -1,9 +1,9 @@
 package com.dh.ondot.schedule.api.response;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.Alarm;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 public record AlarmDto(
         String alarmMode,
@@ -20,7 +20,7 @@ public record AlarmDto(
         return new AlarmDto(
                 alarm.getMode().name(),
                 alarm.isEnabled(),
-                alarm.getTriggeredAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                DateTimeUtils.toSeoulDateTime(alarm.getTriggeredAt()),
                 alarm.getSnooze().isSnoozeEnabled(),
                 alarm.getSnooze().getSnoozeInterval().getValue(),
                 alarm.getSnooze().getSnoozeCount().getValue(),

--- a/src/main/java/com/dh/ondot/schedule/api/response/AlarmSwitchResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/AlarmSwitchResponse.java
@@ -1,9 +1,9 @@
 package com.dh.ondot.schedule.api.response;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 public record AlarmSwitchResponse(
         Long scheduleId,
@@ -14,7 +14,7 @@ public record AlarmSwitchResponse(
         return new AlarmSwitchResponse(
                 schedule.getId(),
                 schedule.getDepartureAlarm().isEnabled(),
-                schedule.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+                DateTimeUtils.toSeoulDateTime(schedule.getUpdatedAt())
         );
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/response/AlarmSwitchResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/AlarmSwitchResponse.java
@@ -3,6 +3,7 @@ package com.dh.ondot.schedule.api.response;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public record AlarmSwitchResponse(
         Long scheduleId,
@@ -13,7 +14,7 @@ public record AlarmSwitchResponse(
         return new AlarmSwitchResponse(
                 schedule.getId(),
                 schedule.getDepartureAlarm().isEnabled(),
-                schedule.getUpdatedAt()
+                schedule.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime()
         );
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/response/PlaceHistoryResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/PlaceHistoryResponse.java
@@ -1,26 +1,23 @@
 package com.dh.ondot.schedule.api.response;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.PlaceHistory;
 
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record PlaceHistoryResponse(
         String title,
         Double longitude,
         Double latitude,
-        String searchedAt
+        LocalDateTime searchedAt
 ) {
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
     public static PlaceHistoryResponse from(PlaceHistory history) {
         return new PlaceHistoryResponse(
                 history.title(),
                 history.longitude(),
                 history.latitude(),
-                FORMATTER.format(history.searchedAt().atZone(KST).toLocalDateTime())
+                DateTimeUtils.toSeoulDateTime(history.searchedAt())
         );
     }
     public static List<PlaceHistoryResponse> fromList(List<PlaceHistory> list) {

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleCreateResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleCreateResponse.java
@@ -1,15 +1,18 @@
 package com.dh.ondot.schedule.api.response;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 public record ScheduleCreateResponse(
         Long scheduleId,
         LocalDateTime createdAt
 ) {
     public static ScheduleCreateResponse of(Schedule schedule) {
-        return new ScheduleCreateResponse(schedule.getId(), schedule.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime());
+        return new ScheduleCreateResponse(
+                schedule.getId(),
+                DateTimeUtils.toSeoulDateTime(schedule.getCreatedAt())
+        );
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleCreateResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleCreateResponse.java
@@ -3,12 +3,13 @@ package com.dh.ondot.schedule.api.response;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public record ScheduleCreateResponse(
         Long scheduleId,
         LocalDateTime createdAt
 ) {
     public static ScheduleCreateResponse of(Schedule schedule) {
-        return new ScheduleCreateResponse(schedule.getId(), schedule.getCreatedAt());
+        return new ScheduleCreateResponse(schedule.getId(), schedule.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime());
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleDetailResponse.java
@@ -1,10 +1,10 @@
 package com.dh.ondot.schedule.api.response;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.api.request.PlaceDto;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 public record ScheduleDetailResponse(
@@ -22,7 +22,7 @@ public record ScheduleDetailResponse(
         return new ScheduleDetailResponse(
                 s.getId(), s.getTitle(), s.getIsRepeat(),
                 s.getRepeatDays() == null ? List.of() : List.copyOf(s.getRepeatDays()),
-                s.getAppointmentAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                DateTimeUtils.toSeoulDateTime(s.getAppointmentAt()),
                 AlarmDto.of(s.getPreparationAlarm()),
                 AlarmDto.of(s.getDepartureAlarm()),
                 PlaceDto.from(s.getDeparturePlace()),

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleParsedResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleParsedResponse.java
@@ -1,0 +1,9 @@
+package com.dh.ondot.schedule.api.response;
+
+import java.time.LocalDateTime;
+
+public record ScheduleParsedResponse(
+        String departurePlaceTitle,
+        LocalDateTime appointmentAt
+) {
+}

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleUpdateResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleUpdateResponse.java
@@ -1,15 +1,18 @@
 package com.dh.ondot.schedule.api.response;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 public record ScheduleUpdateResponse(
         Long scheduleId,
         LocalDateTime updatedAt
 ) {
     public static ScheduleUpdateResponse of(Schedule schedule) {
-        return new ScheduleUpdateResponse(schedule.getId(), schedule.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime());
+        return new ScheduleUpdateResponse(
+                schedule.getId(),
+                DateTimeUtils.toSeoulDateTime(schedule.getUpdatedAt())
+        );
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/response/ScheduleUpdateResponse.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/ScheduleUpdateResponse.java
@@ -3,12 +3,13 @@ package com.dh.ondot.schedule.api.response;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public record ScheduleUpdateResponse(
         Long scheduleId,
         LocalDateTime updatedAt
 ) {
     public static ScheduleUpdateResponse of(Schedule schedule) {
-        return new ScheduleUpdateResponse(schedule.getId(), schedule.getUpdatedAt());
+        return new ScheduleUpdateResponse(schedule.getId(), schedule.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime());
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -1,10 +1,7 @@
 package com.dh.ondot.schedule.api.swagger;
 
 import com.dh.ondot.core.domain.ErrorResponse;
-import com.dh.ondot.schedule.api.request.AlarmSwitchRequest;
-import com.dh.ondot.schedule.api.request.ScheduleCreateRequest;
-import com.dh.ondot.schedule.api.request.ScheduleUpdateRequest;
-import com.dh.ondot.schedule.api.request.VoiceScheduleCreateRequest;
+import com.dh.ondot.schedule.api.request.*;
 import com.dh.ondot.schedule.api.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -165,6 +162,48 @@ public interface ScheduleSwagger {
             @RequestAttribute("memberId") Long memberId,
             @RequestBody VoiceScheduleCreateRequest request
     );
+
+    @Operation(
+            summary="STT 일정 텍스트 파싱",
+            description="한글 문장(예: “내일 6시에 강남역에 약속 있어”)을 장소명·약속시각 JSON 으로 변환",
+            requestBody= @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description="파싱할 문장",
+                    required=true,
+                    content=@Content(
+                            mediaType=MediaType.APPLICATION_JSON_VALUE,
+                            schema=@Schema(implementation=ScheduleParsedRequest.class),
+                            examples=@ExampleObject(value="""
+                        {
+                          "text":"내일 6시에 강남역에 약속 있어"
+                        }"""
+                            )
+                    )
+            ),
+            responses={
+                    @ApiResponse(responseCode="200",
+                            description="파싱 성공",
+                            content=@Content(
+                                    mediaType=MediaType.APPLICATION_JSON_VALUE,
+                                    schema=@Schema(implementation=ScheduleParsedResponse.class),
+                                    examples=@ExampleObject(value="""
+                        {
+                          "departurePlaceTitle":"강남역",
+                          "appointmentAt":"2025-04-16T18:00:00"
+                        }"""
+                                    )
+                            )
+                    ),
+                    @ApiResponse(responseCode="400",
+                            description="파싱 실패",
+                            content=@Content(
+                                    mediaType=MediaType.APPLICATION_JSON_VALUE,
+                                    schema=@Schema(ref="#/components/schemas/ErrorResponse")
+                            )
+                    )
+            }
+    )
+    @PostMapping("/nlp")
+    ScheduleParsedResponse parse(@RequestBody ScheduleParsedRequest request);
 
     /*──────────────────────────────────────────────────────
      * 단일 일정 조회

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -203,7 +203,9 @@ public interface ScheduleSwagger {
             }
     )
     @PostMapping("/nlp")
-    ScheduleParsedResponse parse(@RequestBody ScheduleParsedRequest request);
+    ScheduleParsedResponse parse(
+            Long memberId,
+            @RequestBody ScheduleParsedRequest request);
 
     /*──────────────────────────────────────────────────────
      * 단일 일정 조회

--- a/src/main/java/com/dh/ondot/schedule/app/ParseFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ParseFacade.java
@@ -1,16 +1,24 @@
 package com.dh.ondot.schedule.app;
 
+import com.dh.ondot.member.domain.service.MemberService;
 import com.dh.ondot.schedule.api.response.ScheduleParsedResponse;
+import com.dh.ondot.schedule.domain.service.AiUsageService;
 import com.dh.ondot.schedule.infra.NaturalLanguageParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ParseFacade {
+    private final MemberService memberService;
+    private final AiUsageService aiUsageService;
     private final NaturalLanguageParser parser;
 
-    public ScheduleParsedResponse parse(String sentence) {
+    @Transactional
+    public ScheduleParsedResponse parse(Long memberId, String sentence) {
+        memberService.findExistingMember(memberId);
+        aiUsageService.increaseUsage(memberId);
         return parser.parse(sentence);
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/app/ParseFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ParseFacade.java
@@ -1,0 +1,16 @@
+package com.dh.ondot.schedule.app;
+
+import com.dh.ondot.schedule.api.response.ScheduleParsedResponse;
+import com.dh.ondot.schedule.infra.NaturalLanguageParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ParseFacade {
+    private final NaturalLanguageParser parser;
+
+    public ScheduleParsedResponse parse(String sentence) {
+        return parser.parse(sentence);
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/app/ScheduleCommandFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ScheduleCommandFacade.java
@@ -17,7 +17,7 @@ import java.util.TreeSet;
 
 @Service
 @RequiredArgsConstructor
-public class ScheduleFacade {
+public class ScheduleCommandFacade {
     private final MemberService memberService;
     private final ScheduleService scheduleService;
 

--- a/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
@@ -1,5 +1,6 @@
 package com.dh.ondot.schedule.app;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.member.domain.Member;
 import com.dh.ondot.member.domain.service.MemberService;
 import com.dh.ondot.schedule.api.response.*;
@@ -38,7 +39,7 @@ public class ScheduleQueryFacade {
                 .map(HomeScheduleListItem::from)
                 .toList();
 
-        LocalDateTime now = Instant.now().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+        LocalDateTime now = DateTimeUtils.nowSeoulDateTime();
         LocalDateTime earliest = homeScheduleListItem.stream()
                 .filter(HomeScheduleListItem::isEnabled)
                 .map(HomeScheduleListItem::nextAlarmAt)

--- a/src/main/java/com/dh/ondot/schedule/app/dto/HomeScheduleListItem.java
+++ b/src/main/java/com/dh/ondot/schedule/app/dto/HomeScheduleListItem.java
@@ -1,5 +1,6 @@
 package com.dh.ondot.schedule.app.dto;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.*;
@@ -20,10 +21,10 @@ public record HomeScheduleListItem(
         return new HomeScheduleListItem(
                 schedule.getId(), schedule.getTitle(), schedule.getIsRepeat(),
                 schedule.getRepeatDays() == null ? List.of() : List.copyOf(schedule.getRepeatDays()),
-                schedule.getAppointmentAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
-                schedule.getNextAlarmAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
-                schedule.getPreparationAlarm().getTriggeredAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
-                schedule.getDepartureAlarm().getTriggeredAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
+                DateTimeUtils.toSeoulDateTime(schedule.getAppointmentAt()),
+                DateTimeUtils.toSeoulDateTime(schedule.getNextAlarmAt()),
+                DateTimeUtils.toSeoulDateTime(schedule.getPreparationAlarm().getTriggeredAt()),
+                DateTimeUtils.toSeoulDateTime(schedule.getDepartureAlarm().getTriggeredAt()),
                 schedule.getDepartureAlarm().isEnabled()
         );
     }

--- a/src/main/java/com/dh/ondot/schedule/core/exception/MaxAiUsageLimitExceededException.java
+++ b/src/main/java/com/dh/ondot/schedule/core/exception/MaxAiUsageLimitExceededException.java
@@ -1,0 +1,18 @@
+package com.dh.ondot.schedule.core.exception;
+
+import com.dh.ondot.core.exception.TooManyRequestsException;
+
+import java.time.LocalDate;
+
+import static com.dh.ondot.core.exception.ErrorCode.AI_USAGE_LIMIT_EXCEEDED;
+
+public class MaxAiUsageLimitExceededException extends TooManyRequestsException {
+    public MaxAiUsageLimitExceededException(Long memberId, LocalDate date) {
+        super(AI_USAGE_LIMIT_EXCEEDED.getMessage().formatted(memberId, date.toString()));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return AI_USAGE_LIMIT_EXCEEDED.name();
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/core/exception/OpenAiParsingException.java
+++ b/src/main/java/com/dh/ondot/schedule/core/exception/OpenAiParsingException.java
@@ -1,0 +1,16 @@
+package com.dh.ondot.schedule.core.exception;
+
+import com.dh.ondot.core.exception.BadRequestException;
+
+import static com.dh.ondot.core.exception.ErrorCode.OPEN_AI_PARSING_ERROR;
+
+public class OpenAiParsingException extends BadRequestException {
+    public OpenAiParsingException() {
+        super(OPEN_AI_PARSING_ERROR.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return OPEN_AI_PARSING_ERROR.name();
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/core/exception/UnavailableOpenAiServerException.java
+++ b/src/main/java/com/dh/ondot/schedule/core/exception/UnavailableOpenAiServerException.java
@@ -1,0 +1,16 @@
+package com.dh.ondot.schedule.core.exception;
+
+import com.dh.ondot.core.exception.BadGatewayException;
+
+import static com.dh.ondot.core.exception.ErrorCode.UNAVAILABLE_OPEN_AI_SERVER;
+
+public class UnavailableOpenAiServerException extends BadGatewayException {
+    public UnavailableOpenAiServerException() {
+        super(UNAVAILABLE_OPEN_AI_SERVER.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return UNAVAILABLE_OPEN_AI_SERVER.name();
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/core/exception/UnhandledOpenAiException.java
+++ b/src/main/java/com/dh/ondot/schedule/core/exception/UnhandledOpenAiException.java
@@ -1,0 +1,16 @@
+package com.dh.ondot.schedule.core.exception;
+
+import com.dh.ondot.core.exception.InternalServerException;
+
+import static com.dh.ondot.core.exception.ErrorCode.UNHANDLED_OPEN_AI;
+
+public class UnhandledOpenAiException extends InternalServerException {
+    public UnhandledOpenAiException() {
+        super(UNHANDLED_OPEN_AI.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return UNHANDLED_OPEN_AI.name();
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/domain/AiUsage.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/AiUsage.java
@@ -1,0 +1,45 @@
+package com.dh.ondot.schedule.domain;
+
+import com.dh.ondot.core.domain.BaseTimeEntity;
+import com.dh.ondot.schedule.core.exception.MaxAiUsageLimitExceededException;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "ai_usages")
+public class AiUsage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "usage_id")
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "usage_date", nullable = false)
+    private LocalDate usageDate;
+
+    @Column(name = "count", nullable = false)
+    private Integer count;
+
+    public static AiUsage newForToday(Long memberId, LocalDate date) {
+        return AiUsage.builder()
+                .memberId(memberId)
+                .usageDate(date)
+                .count(1)
+                .build();
+    }
+
+    public void increase() {
+        if (this.count >= 30) {
+            throw new MaxAiUsageLimitExceededException(memberId, LocalDate.now());
+        }
+        this.count++;
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/domain/Schedule.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/Schedule.java
@@ -2,7 +2,7 @@ package com.dh.ondot.schedule.domain;
 
 import com.dh.ondot.core.AggregateRoot;
 import com.dh.ondot.core.domain.BaseTimeEntity;
-import com.dh.ondot.schedule.infra.RepeatDaysConverter;
+import com.dh.ondot.schedule.domain.converter.RepeatDaysConverter;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/dh/ondot/schedule/domain/converter/RepeatDaysConverter.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/converter/RepeatDaysConverter.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.schedule.infra;
+package com.dh.ondot.schedule.domain.converter;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;

--- a/src/main/java/com/dh/ondot/schedule/domain/repository/AiUsageRepository.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/repository/AiUsageRepository.java
@@ -1,0 +1,11 @@
+package com.dh.ondot.schedule.domain.repository;
+
+import com.dh.ondot.schedule.domain.AiUsage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface AiUsageRepository extends JpaRepository<AiUsage, Long> {
+    Optional<AiUsage> findByMemberIdAndUsageDate(Long memberId, LocalDate usageDate);
+}

--- a/src/main/java/com/dh/ondot/schedule/domain/service/AiUsageService.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/service/AiUsageService.java
@@ -1,0 +1,23 @@
+package com.dh.ondot.schedule.domain.service;
+
+import com.dh.ondot.schedule.domain.AiUsage;
+import com.dh.ondot.schedule.domain.repository.AiUsageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AiUsageService {
+    private final AiUsageRepository repo;
+
+    /** 호출 1회당 사용량 +1 */
+    public void increaseUsage(Long memberId) {
+        LocalDate today = LocalDate.now();
+
+        repo.findByMemberIdAndUsageDate(memberId, today)
+                .ifPresentOrElse(AiUsage::increase,
+                        () -> repo.save(AiUsage.newForToday(memberId, today)));
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/infra/NaturalLanguageParser.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/NaturalLanguageParser.java
@@ -1,0 +1,43 @@
+package com.dh.ondot.schedule.infra;
+
+import com.dh.ondot.schedule.api.response.ScheduleParsedResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
+public class NaturalLanguageParser {
+    private static final BeanOutputConverter<ScheduleParsedResponse> CONVERTER =
+            new BeanOutputConverter<>(ScheduleParsedResponse.class);
+
+    private final ChatClient chat;
+
+    private static final String SYSTEM_TMPL = """
+        Date: %s KST.
+        Parse the Korean appointment sentence into JSON:
+        {"departurePlaceTitle":"...","appointmentAt":"yyyy-MM-dd'T'HH:mm:ss"}
+        Rules:
+        - Use relative dates (e.g., “tomorrow”) from Date.
+        - Fix OCR typos to real Korean place names.
+        - Bare hours (e.g., “6시”) → assume 18:00.
+        - No 24‑hr notation; don’t roll times into the next day.
+        """;
+
+    public ScheduleParsedResponse parse(String userText) {
+        String systemPrompt = String.format(
+                SYSTEM_TMPL,
+                LocalDate.now(ZoneId.of("Asia/Seoul"))
+        );
+
+        return chat.prompt()
+                .system(systemPrompt)
+                .user(userText)
+                .call()
+                .entity(CONVERTER);
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -55,6 +55,9 @@ odsay:
   client:
     api-key: ${ODSAY_CLIENT_API_KEY}
 
+openai:
+  api-key: ${OPENAI_API_KEY}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Issue Number
#21 

## As-Is
<!-- 문제 상황 정의 -->
STT로 변환된 일정 텍스트 파싱 기능을 구현합니다

## To-Be
<!-- 변경 사항 -->
- [x] STT 일정 텍스트 파싱 API
  - [x] OpenAI API를 통한 일정 형식으로 파싱
- [x] SpringAI 설정
- [x] OpenAI API 사용량 체크 로직 구현

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 한국어 자연어 일정을 구조화된 데이터로 변환하는 NLP(자연어 처리) API 엔드포인트가 추가되었습니다.
    - 일정 문장을 입력하면 출발지명과 약속 시간을 자동으로 추출해주는 기능이 도입되었습니다.
    - AI 사용량 제한 기능이 도입되어 일일 AI 사용 횟수 초과 시 안내 메시지가 제공됩니다.
    - AI 사용량 집계 및 제한 관리 기능이 추가되었습니다.

- **리팩터링**
    - 일정 관련 기능이 명령 및 파싱 역할로 분리되어 관리됩니다.
    - 기존 일정 파사드 클래스가 명령 파사드로 명확히 분리 및 명명되었습니다.

- **기타**
    - AI 기반 일정 파싱을 위한 내부 Spring AI 및 OpenAI 연동 설정이 추가되었습니다.
    - 시간 정보가 모두 "Asia/Seoul" 타임존 기준으로 일관되게 처리되도록 개선되었습니다.
    - 오류 처리 및 예외 대응이 강화되어 AI 서버 오류 및 사용량 초과 시 적절한 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->