### PR TITLE
[FEAT] Add support for alarm sound list

### DIFF
--- a/src/main/java/com/dh/ondot/member/api/request/OnboardingRequest.java
+++ b/src/main/java/com/dh/ondot/member/api/request/OnboardingRequest.java
@@ -26,7 +26,7 @@ public record OnboardingRequest(
 
         @NotBlank String ringTone,
 
-        @NotNull @Min(0) @Max(1) double volume,
+        @NotNull @Min(0) @Max(1) Double volume,
 
         @NotNull @Size(min = 1) @Valid
         List<@Valid QuestionDto> questions

--- a/src/main/java/com/dh/ondot/member/api/swagger/MemberSwagger.java
+++ b/src/main/java/com/dh/ondot/member/api/swagger/MemberSwagger.java
@@ -89,8 +89,12 @@ public interface MemberSwagger {
             • <code>AlarmMode</code>: SILENT, VIBRATE, SOUND<br>
             • <code>SnoozeInterval</code>: 1, 3, 5, 10, 30, 60 (분)<br>
             • <code>SnoozeCount</code>: -1(INFINITE), 1, 3, 5, 10 (회)<br>
-            • <code>SoundCategory</code>: <i>DEFAULT …</i><br>
-            • <code>RingTone</code>: <i>DEFAULT …</i>
+            • <code>SoundCategory</code>: <i>BRIGHT_ENERGY, FAST_INTENSE</i><br>
+            • <code>RingTone</code>: <i>
+              DANCING_IN_THE_STARDUST, IN_THE_CITY_LIGHTS_MIST, FRACTURED_LOVE,<br>
+              CHASING_LIGHTS, ASHES_OF_US, HEATING_SUN, NO_COPYRIGHT_MUSIC,<br>
+              MEDAL, EXCITING_SPORTS_COMPETITIONS, POSITIVE_WAY,<br>
+              ENERGETIC_HAPPY_UPBEAT_ROCK_MUSIC, ENERGY_CATCHER
             """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -106,9 +110,9 @@ public interface MemberSwagger {
                       "isSnoozeEnabled": true,
                       "snoozeInterval": 5,
                       "snoozeCount": 3,
-                      "soundCategory": "BIRD",
-                      "ringTone": "morning.mp3",
-                      "volume": 0.1,
+                      "soundCategory": "BRIGHT_ENERGY",
+                      "ringTone": "FRACTURED_LOVE",
+                      "volume": 0.2
                       "questions": [
                         { "questionId": 1, "answerId": 3 },
                         { "questionId": 2, "answerId": 5 }

--- a/src/main/java/com/dh/ondot/member/api/swagger/MemberSwagger.java
+++ b/src/main/java/com/dh/ondot/member/api/swagger/MemberSwagger.java
@@ -112,7 +112,7 @@ public interface MemberSwagger {
                       "snoozeCount": 3,
                       "soundCategory": "BRIGHT_ENERGY",
                       "ringTone": "FRACTURED_LOVE",
-                      "volume": 0.2
+                      "volume": 0.2,
                       "questions": [
                         { "questionId": 1, "answerId": 3 },
                         { "questionId": 2, "answerId": 5 }

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/AlarmSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/AlarmSwagger.java
@@ -27,8 +27,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
         • <code>AlarmMode</code>: SILENT, VIBRATE, SOUND<br>
         • <code>SnoozeInterval</code>: 1, 3, 5, 10, 30, 60 (분)<br>
         • <code>SnoozeCount</code>: -1(INFINITE), 1, 3, 5, 10 (회)<br>
-        • <code>SoundCategory</code>: <i>BIRD, OCEAN, DEFAULT …</i><br>
-        • <code>RingTone</code>: <i>beep.mp3, morning.mp3 …</i>
+        • <code>SoundCategory</code>: <i>BRIGHT_ENERGY, FAST_INTENSE</i><br>
+        • <code>RingTone</code>: <i>
+          DANCING_IN_THE_STARDUST, IN_THE_CITY_LIGHTS_MIST, FRACTURED_LOVE,<br>
+          CHASING_LIGHTS, ASHES_OF_US, HEATING_SUN, NO_COPYRIGHT_MUSIC,<br>
+          MEDAL, EXCITING_SPORTS_COMPETITIONS, POSITIVE_WAY,<br>
+          ENERGETIC_HAPPY_UPBEAT_ROCK_MUSIC, ENERGY_CATCHER
+        </i>
         """
 )
 @RequestMapping("/alarms")
@@ -92,9 +97,9 @@ public interface AlarmSwagger {
                             "isSnoozeEnabled": true,
                             "snoozeInterval": 5,
                             "snoozeCount": 3,
-                            "soundCategory": "BIRD",
-                            "ringTone": "morning.mp3",
-                            "volume": 7
+                            "soundCategory": "BRIGHT_ENERGY",
+                            "ringTone": "FRACTURED_LOVE",
+                            "volume": 0.2
                           },
                           "departureAlarm": {
                             "alarmMode": "SOUND",
@@ -103,9 +108,9 @@ public interface AlarmSwagger {
                             "isSnoozeEnabled": false,
                             "snoozeInterval": 0,
                             "snoozeCount": -1,
-                            "soundCategory": "DEFAULT",
-                            "ringTone": "beep.mp3",
-                            "volume": 8
+                            "soundCategory": "BRIGHT_ENERGY",
+                            "ringTone": "FRACTURED_LOVE",
+                            "volume": 0.2
                           }
                         }"""
                                     )

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -31,8 +31,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
         • <code>AlarmMode</code>: SILENT, VIBRATE, SOUND<br>
         • <code>SnoozeInterval</code>: 1, 3, 5, 10, 30, 60 (분)<br>
         • <code>SnoozeCount</code>: -1(INFINITE), 1, 3, 5, 10 (회)<br>
-        • <code>SoundCategory</code>: <i>DEFAULT …</i><br>
-        • <code>RingTone</code>: <i>DEFAULT …</i>
+        • <code>SoundCategory</code>: <i>BRIGHT_ENERGY, FAST_INTENSE</i><br>
+        • <code>RingTone</code>: <i>
+          DANCING_IN_THE_STARDUST, IN_THE_CITY_LIGHTS_MIST, FRACTURED_LOVE,<br>
+          CHASING_LIGHTS, ASHES_OF_US, HEATING_SUN, NO_COPYRIGHT_MUSIC,<br>
+          MEDAL, EXCITING_SPORTS_COMPETITIONS, POSITIVE_WAY,<br>
+          ENERGETIC_HAPPY_UPBEAT_ROCK_MUSIC, ENERGY_CATCHER
+        </i>
         """
 )
 @RequestMapping("/schedules")
@@ -80,9 +85,9 @@ public interface ScheduleSwagger {
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
-                        "soundCategory": "DEFAULT",
-                        "ringTone": "DEFAULT",
-                        "volume": 7
+                        "soundCategory": "BRIGHT_ENERGY",
+                        "ringTone": "FRACTURED_LOVE",
+                        "volume": 0.2
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
@@ -90,9 +95,9 @@ public interface ScheduleSwagger {
                         "isSnoozeEnabled": false,
                         "snoozeInterval": 1,
                         "snoozeCount": -1,
-                        "soundCategory": "DEFAULT",
-                        "ringTone": "DEFAULT",
-                        "volume": 8
+                        "soundCategory": "BRIGHT_ENERGY",
+                        "ringTone": "FRACTURED_LOVE",
+                        "volume": 0.2
                       }
                     }"""
                             )
@@ -481,9 +486,9 @@ public interface ScheduleSwagger {
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
-                        "soundCategory": "DEFAULT",
-                        "ringTone": "DEFAULT",
-                        "volume": 7
+                        "soundCategory": "BRIGHT_ENERGY",
+                        "ringTone": "FRACTURED_LOVE",
+                        "volume": 0.2
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
@@ -491,9 +496,9 @@ public interface ScheduleSwagger {
                         "isSnoozeEnabled": false,
                         "snoozeInterval": 1,
                         "snoozeCount": -1,
-                        "soundCategory": "DEFAULT",
-                        "ringTone": "DEFAULT",
-                        "volume": 8
+                        "soundCategory": "BRIGHT_ENERGY",
+                        "ringTone": "FRACTURED_LOVE",
+                        "volume": 0.2
                       }
                     }""")
                             )
@@ -644,9 +649,9 @@ public interface ScheduleSwagger {
                         "isSnoozeEnabled": true,
                         "snoozeInterval": 5,
                         "snoozeCount": 3,
-                        "soundCategory": "DEFAULT",
-                        "ringTone": "DEFAULT",
-                        "volume": 7
+                        "soundCategory": "BRIGHT_ENERGY",
+                        "ringTone": "FRACTURED_LOVE",
+                        "volume": 0.2
                       },
                       "departureAlarm": {
                         "alarmMode": "SOUND",
@@ -654,9 +659,9 @@ public interface ScheduleSwagger {
                         "isSnoozeEnabled": false,
                         "snoozeInterval": 1,
                         "snoozeCount": -1,
-                        "soundCategory": "DEFAULT",
-                        "ringTone": "DEFAULT",
-                        "volume": 8
+                        "soundCategory": "BRIGHT_ENERGY",
+                        "ringTone": "FRACTURED_LOVE",
+                        "volume": 0.2
                       }
                     }"""
                             )

--- a/src/main/java/com/dh/ondot/schedule/domain/enums/RingTone.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/enums/RingTone.java
@@ -6,7 +6,22 @@ import com.dh.ondot.core.exception.UnsupportedException;
 import java.util.Locale;
 
 public enum RingTone {
-    DEFAULT;
+    // Bright Energy
+    DANCING_IN_THE_STARDUST,
+    IN_THE_CITY_LIGHTS_MIST,
+    FRACTURED_LOVE,
+    CHASING_LIGHTS,
+    ASHES_OF_US,
+    HEATING_SUN,
+    NO_COPYRIGHT_MUSIC,
+
+    // Fast & Intense
+    MEDAL,
+    EXCITING_SPORTS_COMPETITIONS,
+    POSITIVE_WAY,
+    ENERGETIC_HAPPY_UPBEAT_ROCK_MUSIC,
+    ENERGY_CATCHER,
+    ;
 
     public static RingTone from(String ringTone) {
         try {

--- a/src/main/java/com/dh/ondot/schedule/domain/enums/SoundCategory.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/enums/SoundCategory.java
@@ -7,7 +7,9 @@ import java.util.Locale;
 import static com.dh.ondot.core.exception.ErrorCode.UNSUPPORTED_SOUND_CATEGORY;
 
 public enum SoundCategory {
-    DEFAULT;
+    BRIGHT_ENERGY,
+    FAST_INTENSE,
+    ;
 
     public static SoundCategory from(String category) {
         try {


### PR DESCRIPTION
## Issue Number
#27 

## As-Is
<!-- 문제 상황 정의 -->
Add support for alarm sound list

## To-Be
<!-- 변경 사항 -->
- [x] Add “Bright Energy” and “Fast & Intense” categories
- [x] Partially update Swagger documentation

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the available sound categories to include "BRIGHT_ENERGY" and "FAST_INTENSE".
  - Added multiple new ringtone options, such as "DANCING_IN_THE_STARDUST", "FRACTURED_LOVE", and others.

- **Documentation**
  - Updated API documentation and example payloads to reflect the new sound categories and ringtones, as well as updated example volume values.

- **Bug Fixes**
  - Modified volume field to allow null values for improved flexibility in onboarding requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->