### PR TITLE
[FIX] Update response format for full schedule retrieval API

### DIFF
--- a/src/main/java/com/dh/ondot/member/domain/Member.java
+++ b/src/main/java/com/dh/ondot/member/domain/Member.java
@@ -98,6 +98,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public void deactivate() {
+        this.email = "0";
         this.oauthInfo = OauthInfo.of(this.getOauthInfo().getOauthProvider(), "0");
         this.deletedAt = DateTimeUtils.nowSeoulInstant();
     }

--- a/src/main/java/com/dh/ondot/member/domain/Member.java
+++ b/src/main/java/com/dh/ondot/member/domain/Member.java
@@ -98,7 +98,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public void deactivate() {
-        this.email = "0";
+        this.email = "deactivated-" + this.id + "@ondot.com";
         this.oauthInfo = OauthInfo.of(this.getOauthInfo().getOauthProvider(), "0");
         this.deletedAt = DateTimeUtils.nowSeoulInstant();
     }

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -572,6 +572,10 @@ public interface ScheduleSwagger {
                       "scheduleList": [
                         {
                           "scheduleId": 1001,
+                          "startLongitude": 127.0276,
+                          "startLatitude": 37.4979,
+                          "endLongitude": 127.029,
+                          "endLatitude": 37.501,
                           "scheduleTitle": "스터디 모임",
                           "isRepeat": true,
                           "repeatDays": [2,4,6],

--- a/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/app/ScheduleQueryFacade.java
@@ -45,6 +45,8 @@ public class ScheduleQueryFacade {
                 .filter(schedule -> schedule.isScheduleRepeated() || !schedule.isPastAppointment())
                 .toList();
 
+        // todo: need delete logic for expired schedules
+
         List<HomeScheduleListItem> homeScheduleListItem = filteredSchedules.stream()
                 .map(HomeScheduleListItem::from)
                 .toList();

--- a/src/main/java/com/dh/ondot/schedule/app/dto/HomeScheduleListItem.java
+++ b/src/main/java/com/dh/ondot/schedule/app/dto/HomeScheduleListItem.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public record HomeScheduleListItem(
         Long scheduleId,
+        Double startLongitude,
+        Double startLatitude,
+        Double endLongitude,
+        Double endLatitude,
         String scheduleTitle,
         boolean isRepeat,
         List<Integer> repeatDays,
@@ -19,7 +23,12 @@ public record HomeScheduleListItem(
 ) {
     public static HomeScheduleListItem from(Schedule schedule) {
         return new HomeScheduleListItem(
-                schedule.getId(), schedule.getTitle(), schedule.getIsRepeat(),
+                schedule.getId(),
+                schedule.getDeparturePlace().getLongitude(),
+                schedule.getDeparturePlace().getLatitude(),
+                schedule.getArrivalPlace().getLongitude(),
+                schedule.getArrivalPlace().getLatitude(),
+                schedule.getTitle(), schedule.getIsRepeat(),
                 schedule.getRepeatDays() == null ? List.of() : List.copyOf(schedule.getRepeatDays()),
                 DateTimeUtils.toSeoulDateTime(schedule.getAppointmentAt()),
                 DateTimeUtils.toSeoulDateTime(schedule.getNextAlarmAt()),

--- a/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
@@ -38,6 +38,8 @@ public class ScheduleQueryRepository {
 
     public Slice<Schedule> findPageByMember(Long memberId, Pageable pageable) {
         List<Schedule> content = q.selectFrom(s)
+                .join(s.departurePlace, dp).fetchJoin()
+                .join(s.arrivalPlace, ap).fetchJoin()
                 .join(s.preparationAlarm, pa).fetchJoin()
                 .join(s.departureAlarm, da).fetchJoin()
                 .where(s.memberId.eq(memberId))


### PR DESCRIPTION
## Issue Number
#33 

## As-Is
<!-- Describe the current issue or problem -->
Update response format for full schedule retrieval API

## To-Be
<!-- Describe the intended changes or improvements -->
- [x] Update response format for full schedule retrieval API
  - [x] Add latitude and longitude for origin and destination
- [x] Remove email upon member withdrawal

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added geographic coordinates (longitude and latitude) for the start and end points of schedules, now visible in the home schedule list and related API responses.

- **Bug Fixes**
  - Deactivating a member now also resets the member's email information.

- **Documentation**
  - Updated API documentation examples to include new location fields in schedule responses.

- **Chores**
  - Added a comment indicating a future task for expired schedule deletion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->