### PR TITLE
[FEAT] 공공 데이터 기반 이슈 알림 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,8 @@ jobs:
               -e NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} \
               -e NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} \
               -e ODSAY_CLIENT_API_KEY=${{ secrets.ODSAY_CLIENT_API_KEY }} \
+              -e SEOUL_TRANSPORTATION_SERVICE_KEY=${{ secrets.SEOUL_TRANSPORTATION_SERVICE_KEY }} \
+              -e SAFETY_DATA_SERVICE_KEY=${{ secrets.SAFETY_DATA_SERVICE_KEY }} \
               -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
               -e PROD_SERVER_URL=${{ secrets.PROD_SERVER_URL }} \
               --name ${{ secrets.DOCKER_REPOSITORY }} \

--- a/src/main/java/com/dh/ondot/core/annotation/AggregateRoot.java
+++ b/src/main/java/com/dh/ondot/core/annotation/AggregateRoot.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.core;
+package com.dh.ondot.core.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/dh/ondot/core/config/WebConfig.java
+++ b/src/main/java/com/dh/ondot/core/config/WebConfig.java
@@ -32,6 +32,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(tokenInterceptor)
-                .addPathPatterns("/members/**", "/alarms/**", "/places/**", "/schedules/**");
+                .addPathPatterns("/members/**", "/alarms/**", "/places/**", "/schedules/**")
+                .excludePathPatterns("/schedules/*/issues/**");
     }
 }

--- a/src/main/java/com/dh/ondot/member/domain/Member.java
+++ b/src/main/java/com/dh/ondot/member/domain/Member.java
@@ -1,6 +1,6 @@
 package com.dh.ondot.member.domain;
 
-import com.dh.ondot.core.AggregateRoot;
+import com.dh.ondot.core.annotation.AggregateRoot;
 import com.dh.ondot.core.domain.BaseTimeEntity;
 import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.member.domain.enums.MapProvider;

--- a/src/main/java/com/dh/ondot/notification/domain/AlertIssue.java
+++ b/src/main/java/com/dh/ondot/notification/domain/AlertIssue.java
@@ -1,0 +1,10 @@
+package com.dh.ondot.notification.domain;
+
+import java.time.LocalDateTime;
+
+public record AlertIssue(
+        AlertType type,
+        String message,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/dh/ondot/notification/domain/AlertService.java
+++ b/src/main/java/com/dh/ondot/notification/domain/AlertService.java
@@ -1,0 +1,84 @@
+package com.dh.ondot.notification.domain;
+
+import com.dh.ondot.notification.domain.dto.EmergencyAlertDto;
+import com.dh.ondot.notification.domain.dto.SubwayAlertDto;
+import com.dh.ondot.notification.domain.repository.EmergencyAlertRepository;
+import com.dh.ondot.notification.domain.repository.SubwayAlertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AlertService {
+    private final SubwayAlertRepository subwayAlertRepository;
+    private final EmergencyAlertRepository emergencyAlertRepository;
+
+    @Transactional
+    public void saveSubwayAlerts(
+            LocalDate date,
+            List<SubwayAlertDto> dtos
+    ) {
+        if (dtos.isEmpty()) return;
+
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime nextDay = date.plusDays(1).atStartOfDay();
+
+        Set<LocalDateTime> existing = subwayAlertRepository
+                .findAllByCreatedAtBetween(startOfDay, nextDay)
+                .stream()
+                .map(SubwayAlert::getCreatedAt)
+                .collect(Collectors.toSet());
+
+        List<SubwayAlert> toSave = dtos.stream()
+                .filter(dto -> !existing.contains(dto.createdAt()))
+                .map(dto -> SubwayAlert.create(
+                        dto.title(),
+                        dto.content(),
+                        dto.lineName(),
+                        dto.startAt(),
+                        dto.createdAt()
+                ))
+                .toList();
+
+        if (!toSave.isEmpty()) {
+            subwayAlertRepository.saveAll(toSave);
+        }
+    }
+
+    @Transactional
+    public void saveEmergencyAlerts(
+            LocalDate date,
+            List<EmergencyAlertDto> dtos
+    ) {
+        if (dtos.isEmpty()) return;
+
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime nextDay = date.plusDays(1).atStartOfDay();
+
+        Set<LocalDateTime> existing = emergencyAlertRepository
+                .findAllByCreatedAtBetween(startOfDay, nextDay)
+                .stream()
+                .map(EmergencyAlert::getCreatedAt)
+                .collect(Collectors.toSet());
+
+        List<EmergencyAlert> toSave = dtos.stream()
+                .filter(dto -> !existing.contains(dto.createdAt()))
+                .map(dto -> EmergencyAlert.create(
+                        dto.content(),
+                        dto.regionName(),
+                        dto.createdAt()
+                ))
+                .toList();
+
+        if (!toSave.isEmpty()) {
+            emergencyAlertRepository.saveAll(toSave);
+        }
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/domain/AlertType.java
+++ b/src/main/java/com/dh/ondot/notification/domain/AlertType.java
@@ -1,0 +1,6 @@
+package com.dh.ondot.notification.domain;
+
+public enum AlertType {
+    SUBWAY,
+    EMERGENCY_SMS,
+}

--- a/src/main/java/com/dh/ondot/notification/domain/EmergencyAlert.java
+++ b/src/main/java/com/dh/ondot/notification/domain/EmergencyAlert.java
@@ -1,8 +1,10 @@
 package com.dh.ondot.notification.domain;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Entity
@@ -24,7 +26,7 @@ public class EmergencyAlert {
     String regionName;
 
     @Column(name="created_at", nullable = false, unique = true)
-    LocalDateTime createdAt;
+    Instant createdAt;
 
     public static EmergencyAlert create(
             String content,
@@ -34,7 +36,7 @@ public class EmergencyAlert {
         return EmergencyAlert.builder()
                 .content(content)
                 .regionName(regionName)
-                .createdAt(createdAt)
+                .createdAt(DateTimeUtils.toInstant(createdAt))
                 .build();
     }
 }

--- a/src/main/java/com/dh/ondot/notification/domain/EmergencyAlert.java
+++ b/src/main/java/com/dh/ondot/notification/domain/EmergencyAlert.java
@@ -1,0 +1,40 @@
+package com.dh.ondot.notification.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "emergency_alerts")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class EmergencyAlert {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "emergency_alert_id")
+    Long id;
+
+    @Column(name="content", columnDefinition="TEXT")
+    String content;
+
+    @Column(name="region_name")
+    String regionName;
+
+    @Column(name="created_at", nullable = false, unique = true)
+    LocalDateTime createdAt;
+
+    public static EmergencyAlert create(
+            String content,
+            String regionName,
+            LocalDateTime createdAt
+    ) {
+        return EmergencyAlert.builder()
+                .content(content)
+                .regionName(regionName)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/domain/SubwayAlert.java
+++ b/src/main/java/com/dh/ondot/notification/domain/SubwayAlert.java
@@ -1,0 +1,50 @@
+package com.dh.ondot.notification.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "subway_alerts")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SubwayAlert {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subway_alert_id")
+    Long id;
+
+    @Column(name="title")
+    String title;
+
+    @Column(name="content", columnDefinition="TEXT")
+    String content;
+
+    @Column(name="line_name")
+    String lineName;
+
+    @Column(name="start_time")
+    LocalDateTime startTime;
+
+    @Column(name="created_at", nullable = false, unique = true)
+    LocalDateTime createdAt;
+
+    public static SubwayAlert create(
+            String title,
+            String content,
+            String lineName,
+            LocalDateTime startTime,
+            LocalDateTime createdAt
+    ) {
+        return SubwayAlert.builder()
+                .title(title)
+                .content(content)
+                .lineName(lineName)
+                .startTime(startTime)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/domain/SubwayAlert.java
+++ b/src/main/java/com/dh/ondot/notification/domain/SubwayAlert.java
@@ -1,8 +1,10 @@
 package com.dh.ondot.notification.domain;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Entity
@@ -27,10 +29,10 @@ public class SubwayAlert {
     String lineName;
 
     @Column(name="start_time")
-    LocalDateTime startTime;
+    Instant startTime;
 
     @Column(name="created_at", nullable = false, unique = true)
-    LocalDateTime createdAt;
+    Instant createdAt;
 
     public static SubwayAlert create(
             String title,
@@ -43,8 +45,8 @@ public class SubwayAlert {
                 .title(title)
                 .content(content)
                 .lineName(lineName)
-                .startTime(startTime)
-                .createdAt(createdAt)
+                .startTime(DateTimeUtils.toInstant(startTime))
+                .createdAt(DateTimeUtils.toInstant(createdAt))
                 .build();
     }
 }

--- a/src/main/java/com/dh/ondot/notification/domain/dto/EmergencyAlertDto.java
+++ b/src/main/java/com/dh/ondot/notification/domain/dto/EmergencyAlertDto.java
@@ -1,0 +1,10 @@
+package com.dh.ondot.notification.domain.dto;
+
+import java.time.LocalDateTime;
+
+public record EmergencyAlertDto(
+        String content,
+        String regionName,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/dh/ondot/notification/domain/dto/SubwayAlertDto.java
+++ b/src/main/java/com/dh/ondot/notification/domain/dto/SubwayAlertDto.java
@@ -1,0 +1,12 @@
+package com.dh.ondot.notification.domain.dto;
+
+import java.time.LocalDateTime;
+
+public record SubwayAlertDto(
+        String title,
+        String content,
+        String lineName,
+        LocalDateTime startAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/dh/ondot/notification/domain/repository/EmergencyAlertRepository.java
+++ b/src/main/java/com/dh/ondot/notification/domain/repository/EmergencyAlertRepository.java
@@ -1,0 +1,11 @@
+package com.dh.ondot.notification.domain.repository;
+
+import com.dh.ondot.notification.domain.EmergencyAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface EmergencyAlertRepository extends JpaRepository<EmergencyAlert,Long> {
+    List<EmergencyAlert> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/dh/ondot/notification/domain/repository/EmergencyAlertRepository.java
+++ b/src/main/java/com/dh/ondot/notification/domain/repository/EmergencyAlertRepository.java
@@ -3,9 +3,9 @@ package com.dh.ondot.notification.domain.repository;
 import com.dh.ondot.notification.domain.EmergencyAlert;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 public interface EmergencyAlertRepository extends JpaRepository<EmergencyAlert,Long> {
-    List<EmergencyAlert> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    List<EmergencyAlert> findAllByCreatedAtBetween(Instant start, Instant end);
 }

--- a/src/main/java/com/dh/ondot/notification/domain/repository/SubwayAlertRepository.java
+++ b/src/main/java/com/dh/ondot/notification/domain/repository/SubwayAlertRepository.java
@@ -3,9 +3,9 @@ package com.dh.ondot.notification.domain.repository;
 import com.dh.ondot.notification.domain.SubwayAlert;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 public interface SubwayAlertRepository extends JpaRepository<SubwayAlert,Long> {
-    List<SubwayAlert> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    List<SubwayAlert> findAllByCreatedAtBetween(Instant start, Instant end);
 }

--- a/src/main/java/com/dh/ondot/notification/domain/repository/SubwayAlertRepository.java
+++ b/src/main/java/com/dh/ondot/notification/domain/repository/SubwayAlertRepository.java
@@ -1,0 +1,11 @@
+package com.dh.ondot.notification.domain.repository;
+
+import com.dh.ondot.notification.domain.SubwayAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SubwayAlertRepository extends JpaRepository<SubwayAlert,Long> {
+    List<SubwayAlert> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/dh/ondot/notification/domain/service/AlertService.java
+++ b/src/main/java/com/dh/ondot/notification/domain/service/AlertService.java
@@ -1,5 +1,7 @@
-package com.dh.ondot.notification.domain;
+package com.dh.ondot.notification.domain.service;
 
+import com.dh.ondot.notification.domain.EmergencyAlert;
+import com.dh.ondot.notification.domain.SubwayAlert;
 import com.dh.ondot.notification.domain.dto.EmergencyAlertDto;
 import com.dh.ondot.notification.domain.dto.SubwayAlertDto;
 import com.dh.ondot.notification.domain.repository.EmergencyAlertRepository;

--- a/src/main/java/com/dh/ondot/notification/domain/service/AlertService.java
+++ b/src/main/java/com/dh/ondot/notification/domain/service/AlertService.java
@@ -1,5 +1,6 @@
 package com.dh.ondot.notification.domain.service;
 
+import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.notification.domain.EmergencyAlert;
 import com.dh.ondot.notification.domain.SubwayAlert;
 import com.dh.ondot.notification.domain.dto.EmergencyAlertDto;
@@ -10,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,17 +30,17 @@ public class AlertService {
     ) {
         if (dtos.isEmpty()) return;
 
-        LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime nextDay = date.plusDays(1).atStartOfDay();
+        Instant startOfDay = DateTimeUtils.toInstant(date.atStartOfDay());
+        Instant nextDay = DateTimeUtils.toInstant(date.plusDays(1).atStartOfDay());
 
-        Set<LocalDateTime> existing = subwayAlertRepository
+        Set<Instant> existing = subwayAlertRepository
                 .findAllByCreatedAtBetween(startOfDay, nextDay)
                 .stream()
                 .map(SubwayAlert::getCreatedAt)
                 .collect(Collectors.toSet());
 
         List<SubwayAlert> toSave = dtos.stream()
-                .filter(dto -> !existing.contains(dto.createdAt()))
+                .filter(dto -> !existing.contains(DateTimeUtils.toInstant(dto.createdAt())))
                 .map(dto -> SubwayAlert.create(
                         dto.title(),
                         dto.content(),
@@ -61,17 +62,17 @@ public class AlertService {
     ) {
         if (dtos.isEmpty()) return;
 
-        LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime nextDay = date.plusDays(1).atStartOfDay();
+        Instant startOfDay = DateTimeUtils.toInstant(date.atStartOfDay());
+        Instant nextDay = DateTimeUtils.toInstant(date.plusDays(1).atStartOfDay());
 
-        Set<LocalDateTime> existing = emergencyAlertRepository
+        Set<Instant> existing = emergencyAlertRepository
                 .findAllByCreatedAtBetween(startOfDay, nextDay)
                 .stream()
                 .map(EmergencyAlert::getCreatedAt)
                 .collect(Collectors.toSet());
 
         List<EmergencyAlert> toSave = dtos.stream()
-                .filter(dto -> !existing.contains(dto.createdAt()))
+                .filter(dto -> !existing.contains(DateTimeUtils.toInstant(dto.createdAt())))
                 .map(dto -> EmergencyAlert.create(
                         dto.content(),
                         dto.regionName(),

--- a/src/main/java/com/dh/ondot/notification/domain/service/EmergencyAlertService.java
+++ b/src/main/java/com/dh/ondot/notification/domain/service/EmergencyAlertService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.*;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,8 +23,8 @@ public class EmergencyAlertService {
         String allRegion = provinceKey + " 전체";
 
         LocalDate today = DateTimeUtils.nowSeoulDate();
-        LocalDateTime from = today.atStartOfDay();
-        LocalDateTime to   = today.plusDays(1).atStartOfDay();
+        Instant from = DateTimeUtils.toInstant(today.atStartOfDay());
+        Instant to = DateTimeUtils.toInstant(today.plusDays(1).atStartOfDay());
         List<EmergencyAlert> alerts = emergencyAlertRepository.findAllByCreatedAtBetween(from, to);
 
         List<String> contents = alerts.stream()

--- a/src/main/java/com/dh/ondot/notification/domain/service/EmergencyAlertService.java
+++ b/src/main/java/com/dh/ondot/notification/domain/service/EmergencyAlertService.java
@@ -1,0 +1,62 @@
+package com.dh.ondot.notification.domain.service;
+
+import com.dh.ondot.core.util.DateTimeUtils;
+import com.dh.ondot.notification.domain.EmergencyAlert;
+import com.dh.ondot.notification.domain.repository.EmergencyAlertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EmergencyAlertService {
+    private final EmergencyAlertRepository emergencyAlertRepository;
+
+    @Transactional(readOnly = true)
+    public String getIssuesByAddress(String roadAddress) {
+        String regionKey = extractRegionKey(roadAddress);
+        String provinceKey = extractProvince(roadAddress);
+        String allRegion = provinceKey + " 전체";
+
+        LocalDate today = DateTimeUtils.nowSeoulDate();
+        LocalDateTime from = today.atStartOfDay();
+        LocalDateTime to   = today.plusDays(1).atStartOfDay();
+        List<EmergencyAlert> alerts = emergencyAlertRepository.findAllByCreatedAtBetween(from, to);
+
+        List<String> contents = alerts.stream()
+                .filter(a -> matchesRegionCSV(a.getRegionName(), regionKey, allRegion))
+                .map(EmergencyAlert::getContent)
+                .collect(Collectors.toList());
+
+        return String.join("\n", contents);
+    }
+
+    // “서울특별시 동작구 흑석로23-2” → “서울특별시 동작구”
+    private String extractRegionKey(String roadAddress) {
+        String[] tok = roadAddress.split("\\s+");
+        if (tok.length >= 2) return tok[0] + " " + tok[1];
+        if (tok.length == 1) return tok[0];
+        return "";
+    }
+
+    // “서울특별시 동작구 흑석로23-2” → “서울특별시”
+    private String extractProvince(String roadAddress) {
+        String[] tok = roadAddress.split("\\s+");
+        return tok.length >= 1 ? tok[0] : "";
+    }
+
+    private boolean matchesRegionCSV(String regionCsv, String regionKey, String allRegion) {
+        for (String part : regionCsv.split(",")) {
+            String r = part.trim();
+            if (r.equals(regionKey) || r.equals(allRegion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/infra/EmergencyAlertBatchJob.java
+++ b/src/main/java/com/dh/ondot/notification/infra/EmergencyAlertBatchJob.java
@@ -1,0 +1,34 @@
+package com.dh.ondot.notification.infra;
+
+import com.dh.ondot.core.util.DateTimeUtils;
+import com.dh.ondot.notification.domain.AlertService;
+import com.dh.ondot.notification.domain.dto.EmergencyAlertDto;
+import com.dh.ondot.notification.domain.dto.SubwayAlertDto;
+import com.dh.ondot.notification.infra.api.EmergencyAlertApi;
+import com.dh.ondot.notification.infra.api.SubwayAlertApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class EmergencyAlertBatchJob {
+    private static final String EVERY_20_MINUTES = "0 0/20 * * * *";
+
+    private final SubwayAlertApi subwayAlertApi;
+    private final EmergencyAlertApi emergencyAlertApi;
+    private final AlertService alertService;
+
+    @Scheduled(cron = EVERY_20_MINUTES)
+    public void refreshPublicAlerts() {
+        LocalDate today = DateTimeUtils.nowSeoulDate();
+        List<SubwayAlertDto> subwayDtos = subwayAlertApi.fetchAllAlertsByDate(today);
+        alertService.saveSubwayAlerts(today, subwayDtos);
+
+        List<EmergencyAlertDto> emergencyDtos = emergencyAlertApi.fetchAllAlertsByDate(today);
+        alertService.saveEmergencyAlerts(today, emergencyDtos);
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/infra/PublicAlertBatchJob.java
+++ b/src/main/java/com/dh/ondot/notification/infra/PublicAlertBatchJob.java
@@ -7,12 +7,14 @@ import com.dh.ondot.notification.domain.dto.SubwayAlertDto;
 import com.dh.ondot.notification.infra.api.EmergencyAlertApi;
 import com.dh.ondot.notification.infra.api.SubwayAlertApi;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PublicAlertBatchJob {
@@ -25,10 +27,13 @@ public class PublicAlertBatchJob {
     @Scheduled(cron = EVERY_20_MINUTES)
     public void refreshPublicAlerts() {
         LocalDate today = DateTimeUtils.nowSeoulDate();
-        List<SubwayAlertDto> subwayDtos = subwayAlertApi.fetchAllAlertsByDate(today);
-        alertService.saveSubwayAlerts(today, subwayDtos);
-
-        List<EmergencyAlertDto> emergencyDtos = emergencyAlertApi.fetchAllAlertsByDate(today);
-        alertService.saveEmergencyAlerts(today, emergencyDtos);
+        try {
+            List<SubwayAlertDto> subwayDtos = subwayAlertApi.fetchAllAlertsByDate(today);
+            alertService.saveSubwayAlerts(today, subwayDtos);
+            List<EmergencyAlertDto> emergencyDtos = emergencyAlertApi.fetchAllAlertsByDate(today);
+            alertService.saveEmergencyAlerts(today, emergencyDtos);
+        } catch (Exception e) {
+            log.error("Failed to update public alert data", e);
+        }
     }
 }

--- a/src/main/java/com/dh/ondot/notification/infra/PublicAlertBatchJob.java
+++ b/src/main/java/com/dh/ondot/notification/infra/PublicAlertBatchJob.java
@@ -1,7 +1,7 @@
 package com.dh.ondot.notification.infra;
 
 import com.dh.ondot.core.util.DateTimeUtils;
-import com.dh.ondot.notification.domain.AlertService;
+import com.dh.ondot.notification.domain.service.AlertService;
 import com.dh.ondot.notification.domain.dto.EmergencyAlertDto;
 import com.dh.ondot.notification.domain.dto.SubwayAlertDto;
 import com.dh.ondot.notification.infra.api.EmergencyAlertApi;

--- a/src/main/java/com/dh/ondot/notification/infra/PublicAlertBatchJob.java
+++ b/src/main/java/com/dh/ondot/notification/infra/PublicAlertBatchJob.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class EmergencyAlertBatchJob {
+public class PublicAlertBatchJob {
     private static final String EVERY_20_MINUTES = "0 0/20 * * * *";
 
     private final SubwayAlertApi subwayAlertApi;

--- a/src/main/java/com/dh/ondot/notification/infra/api/EmergencyAlertApi.java
+++ b/src/main/java/com/dh/ondot/notification/infra/api/EmergencyAlertApi.java
@@ -1,0 +1,91 @@
+package com.dh.ondot.notification.infra.api;
+
+import com.dh.ondot.notification.domain.dto.EmergencyAlertDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmergencyAlertApi {
+    private static final DateTimeFormatter YYYYMMDD_SLASH = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+    private static final DateTimeFormatter YYYYMMDD = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final ObjectMapper objectMapper;
+
+    private RestClient restClient;
+    @Value("${external-api.safety-data.base-url}")
+    private String baseUrl;
+    @Value("${external-api.safety-data.service-key}")
+    private String serviceKey;
+
+    @PostConstruct
+    public void init() {
+        this.restClient = RestClient.create(baseUrl);
+    }
+
+    public List<EmergencyAlertDto> fetchAllAlertsByDate(LocalDate date) {
+        String formattedDate = date.format(YYYYMMDD);
+        String resJson = fetchAlerts(formattedDate);
+        JsonNode itemsNode = extractBodyNode(resJson);
+
+        return parseAlerts(itemsNode);
+    }
+
+    private String fetchAlerts(String date) {
+        return restClient.get()
+                .uri(b -> b.queryParam("serviceKey", serviceKey)
+                        .queryParam("crtDt", date)
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
+
+    private JsonNode extractBodyNode(String rawJson) {
+        try {
+            return objectMapper.readTree(rawJson)
+                    .path("body");
+        } catch (Exception e) {
+            log.error("Failed to parse emergency alerts JSON response", e);
+            throw new IllegalStateException("Failed to parse emergency alerts JSON response", e);
+        }
+    }
+
+    private List<EmergencyAlertDto> parseAlerts(JsonNode itemsNode) {
+        if (!itemsNode.isArray()) {
+            return Collections.emptyList();
+        }
+
+        List<EmergencyAlertDto> alerts = new ArrayList<>();
+        for (JsonNode node : itemsNode) {
+            try {
+                alerts.add(mapToDto(node));
+            } catch (Exception e) {
+                log.error("Failed to map emergency alert JSON node to DTO: {}", node.toString(), e);
+            }
+        }
+        return alerts;
+    }
+
+    private EmergencyAlertDto mapToDto(JsonNode node) {
+        String content = node.path("MSG_CN").asText("");
+        String region = node.path("RCPTN_RGN_NM").asText("");
+        String createDateTime = node.path("CRT_DT").asText("");
+        LocalDateTime issuedAt = LocalDateTime.parse(createDateTime, YYYYMMDD_SLASH);
+
+        return new EmergencyAlertDto(content, region, issuedAt);
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/infra/api/SubwayAlertApi.java
+++ b/src/main/java/com/dh/ondot/notification/infra/api/SubwayAlertApi.java
@@ -1,0 +1,107 @@
+package com.dh.ondot.notification.infra.api;
+
+import com.dh.ondot.notification.domain.dto.SubwayAlertDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubwayAlertApi {
+    private static final DateTimeFormatter YYYYMMDD = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final ObjectMapper objectMapper;
+
+    private RestClient restClient;
+    @Value("${external-api.seoul-transportation.base-url}")
+    private String baseUrl;
+    @Value("${external-api.seoul-transportation.service-key}")
+    private String serviceKey;
+
+    @PostConstruct
+    public void init() {
+        this.restClient = RestClient.create(baseUrl);
+    }
+
+    public List<SubwayAlertDto> fetchAllAlertsByDate(LocalDate date) {
+        String formattedDate = date.format(YYYYMMDD);
+        String resJson = fetchAlerts(formattedDate);
+        JsonNode itemsNode = extractItemsNode(resJson);
+
+        return parseItems(itemsNode);
+    }
+
+    private String fetchAlerts(String date) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("dataType", "JSON")
+                .queryParam("srchStartNoftOcrnYmd", date)
+                .queryParam("srchEndNoftOcrnYmd", date)
+                // build(true) → 컴포넌트들(여기서는 serviceKey 등)이 이미 인코딩된 상태라고 보고 다시 인코딩하지 않도록 처리
+                .build(true)
+                .toUri();
+
+        return restClient.get()
+                .uri(uri)
+                .retrieve()
+                .body(String.class);
+    }
+
+    private JsonNode extractItemsNode(String rawJson) {
+        try {
+            JsonNode root = objectMapper.readTree(rawJson);
+            return root.path("response")
+                    .path("body")
+                    .path("items")
+                    .path("item");
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse subway alert JSON response", e);
+            throw new IllegalStateException("Failed to parse subway alert JSON response", e);
+        }
+    }
+
+    private List<SubwayAlertDto> parseItems(JsonNode itemsNode) {
+        if (!itemsNode.isArray()) {
+            return Collections.emptyList();
+        }
+
+        List<SubwayAlertDto> alerts = new ArrayList<>();
+        for (JsonNode node : itemsNode) {
+            try {
+                alerts.add(mapToDto(node));
+            } catch (Exception e) {
+                log.error("Failed to map alert JSON node to DTO: {}", node.toString(), e);
+            }
+        }
+        return alerts;
+    }
+
+    private SubwayAlertDto mapToDto(JsonNode node) {
+        String title = node.path("noftTtl").asText();
+        String content = node.path("noftCn").asText();
+        String lineName = node.path("lineNmLst").asText();
+        String beginDateTime = node.path("xcseSitnBgngDt").asText();
+        String notificationOccurrenceTime = node.path("noftOcrnDt").asText();
+        LocalDateTime startAt = LocalDateTime.parse(beginDateTime);
+        LocalDateTime createdAt = LocalDateTime.parse(notificationOccurrenceTime);
+
+        return new SubwayAlertDto(title, content, lineName, startAt, createdAt);
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
+++ b/src/main/java/com/dh/ondot/schedule/api/ScheduleController.java
@@ -87,6 +87,14 @@ public class ScheduleController implements ScheduleSwagger {
     }
 
     @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{scheduleId}/issues")
+    public String getScheduleIssues(
+            @PathVariable Long scheduleId
+    ) {
+        return scheduleQueryFacade.getIssues(scheduleId);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping
     public HomeScheduleListResponse getSchedules(
             @RequestAttribute("memberId") Long memberId,

--- a/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
+++ b/src/main/java/com/dh/ondot/schedule/api/swagger/ScheduleSwagger.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -538,6 +539,66 @@ public interface ScheduleSwagger {
     @GetMapping("/{scheduleId}")
     ScheduleDetailResponse getSchedule(
             @RequestAttribute("memberId") Long memberId,
+            @PathVariable Long scheduleId
+    );
+
+    /*──────────────────────────────────────────────────────
+     * 일정별 이슈 조회
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary     = "일정별 이슈 조회",
+            description = """
+            <code>scheduleId</code>에 해당하는 일정의 <b>도착지</b> 주변 긴급 재난문자 및 지하철 알림 메시지를 한데 모아<br>
+            각 메시지를 줄바꿈(`\\n`)으로 구분한 단일 문자열로 반환합니다.<br>
+            사용자가 설정한 일정의 도착지에 등록된 이슈를 빠르게 확인할 때 사용합니다.
+            """,
+            parameters  = {
+                    @Parameter(
+                            name        = "scheduleId",
+                            in          = ParameterIn.PATH,
+                            required    = true,
+                            description = "조회할 스케줄 ID",
+                            example     = "1001"
+                    )
+            },
+            responses   = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description  = "이슈 조회 성공",
+                            content      = @Content(
+                                    mediaType = MediaType.TEXT_PLAIN_VALUE,
+                                    schema    = @Schema(type = "string"),
+                                    examples  = @ExampleObject(value = """
+                        목적지 인근에 다음과 같은 이슈가 있습니다.  
+                        오늘 06:09:03: 3호선 특정장애인단체 시위 예정으로 지연될 수 있습니다.  
+                        오늘 03:07:04: 서울특별시 동작구에 호우경보가 발령되었습니다.  
+                        """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description  = "스케줄 또는 멤버를 찾을 수 없음",
+                            content      = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema    = @Schema(implementation = ErrorResponse.class),
+                                    examples  = {
+                                            @ExampleObject(
+                                                    name    = "NOT_FOUND_SCHEDULE",
+                                                    summary = "스케줄 없음",
+                                                    value   = """
+                            {
+                              "errorCode": "NOT_FOUND_SCHEDULE",
+                              "message": "일정을 찾을 수 없습니다. ScheduleId : 1001"
+                            }
+                            """
+                                            )
+                                    }
+                            )
+                    )
+            }
+    )
+    public String getScheduleIssues(
             @PathVariable Long scheduleId
     );
 

--- a/src/main/java/com/dh/ondot/schedule/application/ScheduleCommandFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/application/ScheduleCommandFacade.java
@@ -17,7 +17,7 @@ import com.dh.ondot.schedule.domain.service.AiUsageService;
 import com.dh.ondot.schedule.domain.service.PlaceService;
 import com.dh.ondot.schedule.domain.service.RouteService;
 import com.dh.ondot.schedule.domain.service.ScheduleService;
-import com.dh.ondot.schedule.infra.OpenAiPromptApi;
+import com.dh.ondot.schedule.infra.api.OpenAiPromptApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/dh/ondot/schedule/application/ScheduleQueryFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/application/ScheduleQueryFacade.java
@@ -66,7 +66,7 @@ public class ScheduleQueryFacade {
         Schedule schedule = scheduleQueryRepository.findScheduleById(scheduleId)
                 .orElseThrow(() -> new NotFoundScheduleException(scheduleId));
         String roadAddress = schedule.getArrivalPlace().getRoadAddress();
-        // todo: 지하철 알림 추가
+        // todo: 출발지 기반 긴급 알림, 지하철 알림 추가
         return emergencyAlertService.getIssuesByAddress(roadAddress);
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/application/ScheduleQueryFacade.java
+++ b/src/main/java/com/dh/ondot/schedule/application/ScheduleQueryFacade.java
@@ -2,6 +2,7 @@ package com.dh.ondot.schedule.application;
 
 import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.member.domain.service.MemberService;
+import com.dh.ondot.notification.domain.service.EmergencyAlertService;
 import com.dh.ondot.schedule.api.response.*;
 import com.dh.ondot.schedule.application.dto.HomeScheduleListItem;
 import com.dh.ondot.schedule.core.exception.NotFoundScheduleException;
@@ -22,7 +23,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ScheduleQueryFacade {
     private final MemberService memberService;
-    private final ScheduleQueryRepository  scheduleQueryRepository;
+    private final EmergencyAlertService emergencyAlertService;
+    private final ScheduleQueryRepository scheduleQueryRepository;
 
     public Schedule findOne(Long memberId, Long scheduleId) {
         memberService.findExistingMember(memberId);
@@ -57,5 +59,14 @@ public class ScheduleQueryFacade {
                 .orElse(null);
 
         return HomeScheduleListResponse.of(earliest, homeScheduleListItem, slice.hasNext());
+    }
+
+    @Transactional(readOnly = true)
+    public String getIssues(Long scheduleId) {
+        Schedule schedule = scheduleQueryRepository.findScheduleById(scheduleId)
+                .orElseThrow(() -> new NotFoundScheduleException(scheduleId));
+        String roadAddress = schedule.getArrivalPlace().getRoadAddress();
+        // todo: 지하철 알림 추가
+        return emergencyAlertService.getIssuesByAddress(roadAddress);
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/domain/Schedule.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/Schedule.java
@@ -1,6 +1,6 @@
 package com.dh.ondot.schedule.domain;
 
-import com.dh.ondot.core.AggregateRoot;
+import com.dh.ondot.core.annotation.AggregateRoot;
 import com.dh.ondot.core.domain.BaseTimeEntity;
 import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.domain.converter.RepeatDaysConverter;

--- a/src/main/java/com/dh/ondot/schedule/domain/service/RouteService.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/service/RouteService.java
@@ -1,7 +1,7 @@
 package com.dh.ondot.schedule.domain.service;
 
 import com.dh.ondot.core.util.GeoUtils;
-import com.dh.ondot.schedule.infra.OdsayPathApi;
+import com.dh.ondot.schedule.infra.api.OdsayPathApi;
 import com.dh.ondot.schedule.infra.dto.OdsayRouteApiResponse;
 import com.dh.ondot.schedule.infra.exception.OdsayTooCloseException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
@@ -25,6 +25,15 @@ public class ScheduleQueryRepository {
 
     private final JPAQueryFactory q;
 
+    public Optional<Schedule> findScheduleById(Long scheduleId) {
+        Schedule result = q.selectFrom(s)
+                .join(s.departurePlace, dp).fetchJoin()
+                .join(s.arrivalPlace, ap).fetchJoin()
+                .where(s.id.eq(scheduleId))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
     public Optional<Schedule> findScheduleByMemberIdAndId(Long memberId, Long scheduleId) {
         Schedule result = q.selectFrom(s)
                 .join(s.preparationAlarm, pa).fetchJoin()

--- a/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/ScheduleQueryRepository.java
@@ -17,13 +17,13 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class ScheduleQueryRepository {
-    private final JPAQueryFactory q;
-
     private static final QSchedule s  = QSchedule.schedule;
     private static final QAlarm pa = new QAlarm("pa");// preparationAlarm
     private static final QAlarm da = new QAlarm("da");// departureAlarm
     private static final QPlace dp = new QPlace("dp");// departurePlace
     private static final QPlace ap = new QPlace("ap");// arrivalPlace
+
+    private final JPAQueryFactory q;
 
     public Optional<Schedule> findScheduleByMemberIdAndId(Long memberId, Long scheduleId) {
         Schedule result = q.selectFrom(s)

--- a/src/main/java/com/dh/ondot/schedule/infra/api/KakaoSearchRoadAddressApi.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/api/KakaoSearchRoadAddressApi.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.schedule.infra;
+package com.dh.ondot.schedule.infra.api;
 
 import com.dh.ondot.schedule.application.SearchRoadAddressApi;
 import com.dh.ondot.schedule.application.dto.PlaceSearchResult;

--- a/src/main/java/com/dh/ondot/schedule/infra/api/NaverSearchPlaceApi.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/api/NaverSearchPlaceApi.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.schedule.infra;
+package com.dh.ondot.schedule.infra.api;
 
 import com.dh.ondot.schedule.application.SearchPlaceApi;
 import com.dh.ondot.schedule.application.dto.PlaceSearchResult;

--- a/src/main/java/com/dh/ondot/schedule/infra/api/OdsayPathApi.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/api/OdsayPathApi.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.schedule.infra;
+package com.dh.ondot.schedule.infra.api;
 
 import com.dh.ondot.schedule.infra.config.OdsayApiConfig;
 import com.dh.ondot.schedule.infra.dto.OdsayErrorResponse;

--- a/src/main/java/com/dh/ondot/schedule/infra/api/OpenAiPromptApi.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/api/OpenAiPromptApi.java
@@ -18,11 +18,7 @@ import org.springframework.web.client.HttpServerErrorException;
 @Component
 @RequiredArgsConstructor
 public class OpenAiPromptApi {
-    private static final BeanOutputConverter<ScheduleParsedResponse> CONVERTER =
-            new BeanOutputConverter<>(ScheduleParsedResponse.class);
-
-    private final ChatClient chat;
-
+    private static final BeanOutputConverter<ScheduleParsedResponse> CONVERTER = new BeanOutputConverter<>(ScheduleParsedResponse.class);
     private static final String SYSTEM_TMPL = """
         Date: %s KST.
         Parse the Korean appointment sentence into JSON:
@@ -33,6 +29,8 @@ public class OpenAiPromptApi {
         - Bare hours (e.g., “6시”) → assume 18:00.
         - No 24‑hr notation; don’t roll times into the next day.
         """;
+
+    private final ChatClient chat;
 
     @Retryable(
             retryFor = { HttpServerErrorException.class },

--- a/src/main/java/com/dh/ondot/schedule/infra/api/OpenAiPromptApi.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/api/OpenAiPromptApi.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.schedule.infra;
+package com.dh.ondot.schedule.infra.api;
 
 import com.dh.ondot.core.util.DateTimeUtils;
 import com.dh.ondot.schedule.api.response.ScheduleParsedResponse;

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -72,6 +72,14 @@ odsay:
   base-url: https://api.odsay.com/v1/api/searchPubTransPathT
   api-key: ${ODSAY_CLIENT_API_KEY}
 
+external-api:
+  seoul-transportation:
+    base-url: https://apis.data.go.kr/B553766/ntce/getNtceList
+    service-key: ${SEOUL_TRANSPORTATION_SERVICE_KEY}
+  safety-data:
+    base-url: https://www.safetydata.go.kr//V2/api/DSSP-IF-00247
+    service-key: ${SAFETY_DATA_SERVICE_KEY}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Issue Number
#39

## As-Is
<!-- Describe the current issue or problem -->
- 공공 알림(지하철 알림, 재난 문자 등)을 수집 및 저장할 수 있는 인프라, 도메인 구조가 부재
- 일정 도착지 기반으로 사용자에게 공공 이슈를 전달할 수 있는 API가 존재하지 않음
- 외부 API로부터 수신한 데이터를 중복 저장 방지 없이 단순히 저장하거나, 활용하지 않음
- Swagger 문서 및 인증 예외 경로 설정도 부족하여 외부 연동이나 테스트가 어려움


## To-Be
<!-- Describe the intended changes or improvements -->
- 지하철 알림(SubwayAlert)과 긴급 재난 문자(EmergencyAlert) 도메인 모델 및 저장소 구현
- 외부 API 연동 클래스(SubwayAlertApi, EmergencyAlertApi) 구현 및 DTO 계층 설계
- 알림 저장을 위한 AlertService 구현: createdAt 기준 중복 제거 후 저장
- 20분 간격 스케줄링(PublicAlertBatchJob)을 통해 알림 데이터 수집 자동화
- 일정 도착지를 기반으로 공공 이슈를 조회하는 API(/schedules/{scheduleId}/issues) 추가
- 도착지 주소 파싱을 통한 지역 단위 재난문자 필터링 로직 구현
- Swagger 문서화로 API 사용 목적 및 예시 명확화
- 해당 API 경로에 대해 인증 인터셉터 예외 처리(/schedules/*/issues/**)

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 일정별 도착지 인근의 긴급재난 및 지하철 알림 이슈를 조회하는 GET 엔드포인트(`/schedules/{scheduleId}/issues`)가 추가되었습니다.
  * 긴급재난 및 지하철 알림 정보를 저장/조회하는 서비스, 도메인, DTO, 저장소가 추가되었습니다.
  * 20분마다 공공 알림 데이터를 자동으로 갱신하는 배치 작업이 도입되었습니다.
  * 긴급재난 및 지하철 알림 데이터를 외부 API에서 조회하는 기능이 추가되었습니다.

* **버그 수정**
  * 일정 이슈 관련 경로에 대한 인증 인터셉터 적용 예외가 추가되었습니다.

* **문서화**
  * 일정별 이슈 조회 API에 대한 Swagger 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->