### PR TITLE
[FEAT] 사용자 준비시간 조회 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/dh/ondot/member/api/MemberController.java
+++ b/src/main/java/com/dh/ondot/member/api/MemberController.java
@@ -3,9 +3,11 @@ package com.dh.ondot.member.api;
 import com.dh.ondot.member.api.request.OnboardingRequest;
 import com.dh.ondot.member.api.request.UpdateHomeAddressRequest;
 import com.dh.ondot.member.api.request.UpdateMapProviderRequest;
+import com.dh.ondot.member.api.request.UpdatePreparationTimeRequest;
 import com.dh.ondot.member.api.request.WithdrawalRequest;
 import com.dh.ondot.member.api.response.HomeAddressResponse;
 import com.dh.ondot.member.api.response.OnboardingResponse;
+import com.dh.ondot.member.api.response.PreparationTimeResponse;
 import com.dh.ondot.member.api.response.UpdateHomeAddressResponse;
 import com.dh.ondot.member.api.response.MapProviderResponse;
 import com.dh.ondot.member.api.swagger.MemberSwagger;
@@ -84,5 +86,24 @@ public class MemberController implements MemberSwagger {
         );
 
         return UpdateHomeAddressResponse.from(address);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/preparation-time")
+    public PreparationTimeResponse getPreparationTime(
+            @RequestAttribute("memberId") Long memberId
+    ) {
+        Member member = memberFacade.getMember(memberId);
+        return PreparationTimeResponse.from(member);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/preparation-time")
+    public PreparationTimeResponse updatePreparationTime(
+            @RequestAttribute("memberId") Long memberId,
+            @Valid @RequestBody UpdatePreparationTimeRequest request
+    ) {
+        Member member = memberFacade.updatePreparationTime(memberId, request.preparationTime());
+        return PreparationTimeResponse.from(member);
     }
 }

--- a/src/main/java/com/dh/ondot/member/api/request/UpdatePreparationTimeRequest.java
+++ b/src/main/java/com/dh/ondot/member/api/request/UpdatePreparationTimeRequest.java
@@ -1,0 +1,13 @@
+package com.dh.ondot.member.api.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdatePreparationTimeRequest(
+        @NotNull
+        @Min(value = 1, message = "준비 시간은 최소 1분이어야 합니다.")
+        @Max(value = 240, message = "준비 시간은 최대 240분까지 가능합니다.")
+        Integer preparationTime
+) {
+}

--- a/src/main/java/com/dh/ondot/member/api/response/PreparationTimeResponse.java
+++ b/src/main/java/com/dh/ondot/member/api/response/PreparationTimeResponse.java
@@ -1,0 +1,18 @@
+package com.dh.ondot.member.api.response;
+
+import com.dh.ondot.core.util.TimeUtils;
+import com.dh.ondot.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+public record PreparationTimeResponse(
+        Integer preparationTime,
+        LocalDateTime updatedAt
+) {
+    public static PreparationTimeResponse from(Member member) {
+        return new PreparationTimeResponse(
+                member.getPreparationTime(),
+                TimeUtils.toSeoulDateTime(member.getUpdatedAt())
+        );
+    }
+}

--- a/src/main/java/com/dh/ondot/member/api/swagger/MemberSwagger.java
+++ b/src/main/java/com/dh/ondot/member/api/swagger/MemberSwagger.java
@@ -3,6 +3,7 @@ package com.dh.ondot.member.api.swagger;
 import com.dh.ondot.member.api.request.OnboardingRequest;
 import com.dh.ondot.member.api.request.UpdateHomeAddressRequest;
 import com.dh.ondot.member.api.request.UpdateMapProviderRequest;
+import com.dh.ondot.member.api.request.UpdatePreparationTimeRequest;
 import com.dh.ondot.member.api.request.WithdrawalRequest;
 import com.dh.ondot.member.api.response.*;
 import com.dh.ondot.core.domain.ErrorResponse;
@@ -21,15 +22,15 @@ import org.springframework.web.bind.annotation.*;
 @Tag(
         name = "Member API",
         description = """
-        <b>AccessToken (Authorization: Bearer JWT)</b>은 필수입니다.<br><br>
-        <b>🏠 AddressType ENUM</b> : <code>HOME</code><br>
-        <b>🗺 MapProvider ENUM</b> : <code>NAVER</code>, <code>KAKAO</code><br><br>
-        <b>📢 주요 ErrorCode</b><br>
-        • <code>NOT_FOUND_MEMBER</code> : 회원 미존재<br>
-        • <code>NOT_FOUND_ADDRESS</code> : HOME 주소 미존재<br>
-        • <code>FIELD_ERROR</code> / <code>URL_PARAMETER_ERROR</code> : 입력 검증 오류<br>
-        • <code>UNSUPPORTED_MAP_PROVIDER</code> : 지원하지 않는 MapProvider 값<br>
-        """
+                <b>AccessToken (Authorization: Bearer JWT)</b>은 필수입니다.<br><br>
+                <b>🏠 AddressType ENUM</b> : <code>HOME</code><br>
+                <b>🗺 MapProvider ENUM</b> : <code>NAVER</code>, <code>KAKAO</code><br><br>
+                <b>📢 주요 ErrorCode</b><br>
+                • <code>NOT_FOUND_MEMBER</code> : 회원 미존재<br>
+                • <code>NOT_FOUND_ADDRESS</code> : HOME 주소 미존재<br>
+                • <code>FIELD_ERROR</code> / <code>URL_PARAMETER_ERROR</code> : 입력 검증 오류<br>
+                • <code>UNSUPPORTED_MAP_PROVIDER</code> : 지원하지 않는 MapProvider 값<br>
+                """
 )
 @RequestMapping("/members")
 public interface MemberSwagger {
@@ -40,15 +41,15 @@ public interface MemberSwagger {
     @Operation(
             summary = "회원 탈퇴",
             description = """
-            회원 탈퇴 요청을 처리합니다. 탈퇴 사유 ID는 필수이며, 기타 사유는 300자 이내로 입력할 수 있습니다.
-        
-            사유 목록(withdrawalReasonId):
-            - ID 1: 지각 방지에 효과를 못 느꼈어요.
-            - ID 2: 일정 등록이나 사용이 번거로웠어요.
-            - ID 3: 알림이 너무 많거나 타이밍이 맞지 않았어요.
-            - ID 4: 제 생활에 딱히 쓸 일이 없었어요.
-            - ID 5: 기타
-            """,
+                    회원 탈퇴 요청을 처리합니다. 탈퇴 사유 ID는 필수이며, 기타 사유는 300자 이내로 입력할 수 있습니다.
+                    
+                    사유 목록(withdrawalReasonId):
+                    - ID 1: 지각 방지에 효과를 못 느꼈어요.
+                    - ID 2: 일정 등록이나 사용이 번거로웠어요.
+                    - ID 3: 알림이 너무 많거나 타이밍이 맞지 않았어요.
+                    - ID 4: 제 생활에 딱히 쓸 일이 없었어요.
+                    - ID 5: 기타
+                    """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "탈퇴 요청 정보",
                     required = true,
@@ -56,11 +57,11 @@ public interface MemberSwagger {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = WithdrawalRequest.class),
                             examples = @ExampleObject(value = """
-            {
-              "withdrawalReasonId": 5,
-              "customReason": "서비스가 기대에 미치지 못했어요."
-            }
-            """)
+                                    {
+                                      "withdrawalReasonId": 5,
+                                      "customReason": "서비스가 기대에 미치지 못했어요."
+                                    }
+                                    """)
                     )
             ),
             responses = {
@@ -70,10 +71,10 @@ public interface MemberSwagger {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                                     examples = @ExampleObject(
                                             value = """
-                        {
-                          "errorCode": "NOT_FOUND_MEMBER",
-                          "message": "회원을 찾을 수 없습니다. MemberId : 42"
-                        }"""
+                                                    {
+                                                      "errorCode": "NOT_FOUND_MEMBER",
+                                                      "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                                                    }"""
                                     )))
             }
     )
@@ -95,11 +96,11 @@ public interface MemberSwagger {
                                     examples = @ExampleObject(
                                             name = "success",
                                             value = """
-                        {
-                          "roadAddress": "서울특별시 강남구 테헤란로 123",
-                          "longitude": 127.0276,
-                          "latitude": 37.4979
-                        }"""
+                                                    {
+                                                      "roadAddress": "서울특별시 강남구 테헤란로 123",
+                                                      "longitude": 127.0276,
+                                                      "latitude": 37.4979
+                                                    }"""
                                     ))),
                     @ApiResponse(responseCode = "404",
                             description = "주소 또는 회원 없음",
@@ -109,19 +110,19 @@ public interface MemberSwagger {
                                                     name = "addressNotFound",
                                                     summary = "NOT_FOUND_ADDRESS",
                                                     value = """
-                            {
-                              "errorCode": "NOT_FOUND_ADDRESS",
-                              "message": "회원이 저장한 주소를 찾을 수 없습니다. MemberId : 42"
-                            }"""
+                                                            {
+                                                              "errorCode": "NOT_FOUND_ADDRESS",
+                                                              "message": "회원이 저장한 주소를 찾을 수 없습니다. MemberId : 42"
+                                                            }"""
                                             ),
                                             @ExampleObject(
                                                     name = "memberNotFound",
                                                     summary = "NOT_FOUND_MEMBER",
                                                     value = """
-                            {
-                              "errorCode": "NOT_FOUND_MEMBER",
-                              "message": "회원을 찾을 수 없습니다. MemberId : 42"
-                            }"""
+                                                            {
+                                                              "errorCode": "NOT_FOUND_MEMBER",
+                                                              "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                                                            }"""
                                             )
                                     }))
             }
@@ -135,13 +136,13 @@ public interface MemberSwagger {
     @Operation(
             summary = "회원 MAP 제공자 조회",
             description = """
-        로그인한 회원의 현재 MAP 제공자 정보를 조회합니다.
-        
-        mapProvider:
-        - NAVER
-        - KAKAO
-        - APPLE
-        """,
+                    로그인한 회원의 현재 MAP 제공자 정보를 조회합니다.
+                    
+                    mapProvider:
+                    - NAVER
+                    - KAKAO
+                    - APPLE
+                    """,
             responses = {
                     @ApiResponse(responseCode = "200",
                             description = "조회 성공",
@@ -149,10 +150,10 @@ public interface MemberSwagger {
                                     examples = @ExampleObject(
                                             name = "success",
                                             value = """
-                        {
-                          "mapProvider": "KAKAO",
-                          "updatedAt": "2025-08-10T14:32:00"
-                        }"""
+                                                    {
+                                                      "mapProvider": "KAKAO",
+                                                      "updatedAt": "2025-08-10T14:32:00"
+                                                    }"""
                                     ))),
                     @ApiResponse(responseCode = "404",
                             description = "회원 없음",
@@ -161,10 +162,10 @@ public interface MemberSwagger {
                                             name = "memberNotFound",
                                             summary = "NOT_FOUND_MEMBER",
                                             value = """
-                            {
-                              "errorCode": "NOT_FOUND_MEMBER",
-                              "message": "회원을 찾을 수 없습니다. MemberId : 42"
-                            }"""
+                                                    {
+                                                      "errorCode": "NOT_FOUND_MEMBER",
+                                                      "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                                                    }"""
                                     )))
             }
     )
@@ -177,40 +178,40 @@ public interface MemberSwagger {
     @Operation(
             summary = "온보딩(첫 설정) 완료",
             description = """
-            사용자 온보딩을 완료합니다. <br>
-            <b>🔔 Alarm ENUM</b><br>
-            • <code>AlarmMode</code>: SILENT, VIBRATE, SOUND<br>
-            • <code>SnoozeInterval</code>: 1, 3, 5, 10, 30, 60 (분)<br>
-            • <code>SnoozeCount</code>: -1(INFINITE), 1, 3, 5, 10 (회)<br>
-            • <code>SoundCategory</code>: <i>BRIGHT_ENERGY, FAST_INTENSE</i><br>
-            • <code>RingTone</code>: <i>
-              DANCING_IN_THE_STARDUST, IN_THE_CITY_LIGHTS_MIST, FRACTURED_LOVE,<br>
-              CHASING_LIGHTS, ASHES_OF_US, HEATING_SUN, NO_COPYRIGHT_MUSIC,<br>
-              MEDAL, EXCITING_SPORTS_COMPETITIONS, POSITIVE_WAY,<br>
-              ENERGETIC_HAPPY_UPBEAT_ROCK_MUSIC, ENERGY_CATCHER
-            """,
+                    사용자 온보딩을 완료합니다. <br>
+                    <b>🔔 Alarm ENUM</b><br>
+                    • <code>AlarmMode</code>: SILENT, VIBRATE, SOUND<br>
+                    • <code>SnoozeInterval</code>: 1, 3, 5, 10, 30, 60 (분)<br>
+                    • <code>SnoozeCount</code>: -1(INFINITE), 1, 3, 5, 10 (회)<br>
+                    • <code>SoundCategory</code>: <i>BRIGHT_ENERGY, FAST_INTENSE</i><br>
+                    • <code>RingTone</code>: <i>
+                      DANCING_IN_THE_STARDUST, IN_THE_CITY_LIGHTS_MIST, FRACTURED_LOVE,<br>
+                      CHASING_LIGHTS, ASHES_OF_US, HEATING_SUN, NO_COPYRIGHT_MUSIC,<br>
+                      MEDAL, EXCITING_SPORTS_COMPETITIONS, POSITIVE_WAY,<br>
+                      ENERGETIC_HAPPY_UPBEAT_ROCK_MUSIC, ENERGY_CATCHER
+                    """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     content = @Content(schema = @Schema(implementation = OnboardingRequest.class),
                             examples = @ExampleObject(name = "onboardingRequest",
                                     value = """
-                    {
-                      "preparationTime": 30,
-                      "roadAddress": "서울특별시 강남구 테헤란로 123",
-                      "longitude": 127.0276,
-                      "latitude": 37.4979,
-                      "alarmMode": "VIBRATE",
-                      "isSnoozeEnabled": true,
-                      "snoozeInterval": 5,
-                      "snoozeCount": 3,
-                      "soundCategory": "BRIGHT_ENERGY",
-                      "ringTone": "FRACTURED_LOVE",
-                      "volume": 0.2,
-                      "questions": [
-                        { "questionId": 1, "answerId": 3 },
-                        { "questionId": 2, "answerId": 5 }
-                      ]
-                    }"""
+                                            {
+                                              "preparationTime": 30,
+                                              "roadAddress": "서울특별시 강남구 테헤란로 123",
+                                              "longitude": 127.0276,
+                                              "latitude": 37.4979,
+                                              "alarmMode": "VIBRATE",
+                                              "isSnoozeEnabled": true,
+                                              "snoozeInterval": 5,
+                                              "snoozeCount": 3,
+                                              "soundCategory": "BRIGHT_ENERGY",
+                                              "ringTone": "FRACTURED_LOVE",
+                                              "volume": 0.2,
+                                              "questions": [
+                                                { "questionId": 1, "answerId": 3 },
+                                                { "questionId": 2, "answerId": 5 }
+                                              ]
+                                            }"""
                             ))
             ),
             responses = {
@@ -220,11 +221,11 @@ public interface MemberSwagger {
                                     examples = @ExampleObject(
                                             name = "success",
                                             value = """
-                        {
-                          "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                          "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                          "updatedAt": "2025-05-10T12:34:56"
-                        }"""
+                                                    {
+                                                      "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                                      "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                                      "updatedAt": "2025-05-10T12:34:56"
+                                                    }"""
                                     ))),
                     @ApiResponse(responseCode = "400",
                             description = "검증 오류 / 지원하지 않는 값",
@@ -234,22 +235,22 @@ public interface MemberSwagger {
                                                     name = "fieldError",
                                                     summary = "FIELD_ERROR",
                                                     value = """
-                            {
-                              "errorCode": "FIELD_ERROR",
-                              "message": "입력이 잘못되었습니다.",
-                              "fieldErrors": [
-                                { "field": "preparationTime", "rejectedValue": -1, "reason": "must be between 1 and 240" }
-                              ]
-                            }"""
+                                                            {
+                                                              "errorCode": "FIELD_ERROR",
+                                                              "message": "입력이 잘못되었습니다.",
+                                                              "fieldErrors": [
+                                                                { "field": "preparationTime", "rejectedValue": -1, "reason": "must be between 1 and 240" }
+                                                              ]
+                                                            }"""
                                             ),
                                             @ExampleObject(
                                                     name = "unsupportedMapProvider",
                                                     summary = "UNSUPPORTED_MAP_PROVIDER",
                                                     value = """
-                            {
-                              "errorCode": "UNSUPPORTED_MAP_PROVIDER",
-                              "message": "지원하지 않는 지도 제공자입니다. MapProvider : ABC"
-                            }"""
+                                                            {
+                                                              "errorCode": "UNSUPPORTED_MAP_PROVIDER",
+                                                              "message": "지원하지 않는 지도 제공자입니다. MapProvider : ABC"
+                                                            }"""
                                             )
                                     })),
                     @ApiResponse(responseCode = "404",
@@ -259,10 +260,10 @@ public interface MemberSwagger {
                                             name = "questionNotFound",
                                             summary = "NOT_FOUND_QUESTION",
                                             value = """
-                            {
-                              "errorCode": "NOT_FOUND_QUESTION",
-                              "message": "질문을 찾을 수 없습니다. QuestionId : 99"
-                            }"""
+                                                    {
+                                                      "errorCode": "NOT_FOUND_QUESTION",
+                                                      "message": "질문을 찾을 수 없습니다. QuestionId : 99"
+                                                    }"""
                                     )))
             }
     )
@@ -287,30 +288,30 @@ public interface MemberSwagger {
                                     examples = @ExampleObject(
                                             name = "success",
                                             value = """
-                        {
-                          "mapProvider": "KAKAO",
-                          "updatedAt": "2025-05-11T09:00:00"
-                        }"""
+                                                    {
+                                                      "mapProvider": "KAKAO",
+                                                      "updatedAt": "2025-05-11T09:00:00"
+                                                    }"""
                                     ))),
                     @ApiResponse(responseCode = "400",
                             description = "UNSUPPORTED_MAP_PROVIDER",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                                     examples = @ExampleObject(
                                             value = """
-                        {
-                          "errorCode": "UNSUPPORTED_MAP_PROVIDER",
-                          "message": "지원하지 않는 지도 제공자입니다. MapProvider : ABC"
-                        }"""
+                                                    {
+                                                      "errorCode": "UNSUPPORTED_MAP_PROVIDER",
+                                                      "message": "지원하지 않는 지도 제공자입니다. MapProvider : ABC"
+                                                    }"""
                                     ))),
                     @ApiResponse(responseCode = "404",
                             description = "NOT_FOUND_MEMBER",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                                     examples = @ExampleObject(
                                             value = """
-                        {
-                          "errorCode": "NOT_FOUND_MEMBER",
-                          "message": "회원을 찾을 수 없습니다. MemberId : 42"
-                        }"""
+                                                    {
+                                                      "errorCode": "NOT_FOUND_MEMBER",
+                                                      "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                                                    }"""
                                     )))
             }
     )
@@ -328,11 +329,11 @@ public interface MemberSwagger {
                     content = @Content(schema = @Schema(implementation = UpdateHomeAddressRequest.class),
                             examples = @ExampleObject(
                                     value = """
-                    {
-                      "roadAddress": "서울특별시 강남구 테헤란로 456",
-                      "longitude": 127.0301,
-                      "latitude": 37.4982
-                    }"""
+                                            {
+                                              "roadAddress": "서울특별시 강남구 테헤란로 456",
+                                              "longitude": 127.0301,
+                                              "latitude": 37.4982
+                                            }"""
                             ))
             ),
             responses = {
@@ -342,25 +343,118 @@ public interface MemberSwagger {
                                     examples = @ExampleObject(
                                             name = "success",
                                             value = """
-                        {
-                          "roadAddress": "서울특별시 강남구 테헤란로 456",
-                          "longitude": 127.0301,
-                          "latitude": 37.4982
-                        }"""
+                                                    {
+                                                      "roadAddress": "서울특별시 강남구 테헤란로 456",
+                                                      "longitude": 127.0301,
+                                                      "latitude": 37.4982
+                                                    }"""
                                     ))),
                     @ApiResponse(responseCode = "404",
                             description = "NOT_FOUND_ADDRESS | NOT_FOUND_MEMBER",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                                     examples = @ExampleObject(
                                             value = """
-                        {
-                          "errorCode": "NOT_FOUND_ADDRESS",
-                          "message": "회원이 저장한 주소를 찾을 수 없습니다. MemberId : 42"
-                        }"""
+                                                    {
+                                                      "errorCode": "NOT_FOUND_ADDRESS",
+                                                      "message": "회원이 저장한 주소를 찾을 수 없습니다. MemberId : 42"
+                                                    }"""
                                     )))
             }
     )
     @PatchMapping("/home-address")
     UpdateHomeAddressResponse updateHomeAddress(@RequestAttribute("memberId") Long memberId,
                                                 @RequestBody UpdateHomeAddressRequest request);
+
+    /*──────────────────────────────────────────────────────
+     * 준비 시간 조회
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "회원 준비 시간 조회",
+            description = """
+                    로그인한 회원의 현재 준비 시간(분 단위)을 조회합니다.
+                    준비 시간은 1분에서 240분(4시간) 사이의 값입니다.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = PreparationTimeResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "success",
+                                            value = """
+                                                    {
+                                                      "preparationTime": 30,
+                                                      "updatedAt": "2025-08-30T14:32:00"
+                                                    }"""
+                                    ))),
+                    @ApiResponse(responseCode = "404",
+                            description = "회원 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "memberNotFound",
+                                            summary = "NOT_FOUND_MEMBER",
+                                            value = """
+                                                    {
+                                                      "errorCode": "NOT_FOUND_MEMBER",
+                                                      "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                                                    }"""
+                                    )))
+            }
+    )
+    @GetMapping("/preparation-time")
+    PreparationTimeResponse getPreparationTime(@RequestAttribute("memberId") Long memberId);
+
+    /*──────────────────────────────────────────────────────
+     * 준비 시간 수정
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "회원 준비 시간 수정",
+            description = """
+                    로그인한 회원의 준비 시간을 변경합니다.
+                    준비 시간은 1분에서 240분(4시간) 사이의 값이어야 합니다.
+                    """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = UpdatePreparationTimeRequest.class),
+                            examples = @ExampleObject(value = "{ \"preparationTime\": 45 }"))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "수정 성공",
+                            content = @Content(schema = @Schema(implementation = PreparationTimeResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "success",
+                                            value = """
+                                                    {
+                                                      "preparationTime": 45,
+                                                      "updatedAt": "2025-08-30T15:20:00"
+                                                    }"""
+                                    ))),
+                    @ApiResponse(responseCode = "400",
+                            description = "FIELD_ERROR",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "errorCode": "FIELD_ERROR",
+                                                      "message": "입력이 잘못되었습니다.",
+                                                      "fieldErrors": [
+                                                        { "field": "preparationTime", "rejectedValue": 0, "reason": "준비 시간은 최소 1분이어야 합니다." }
+                                                      ]
+                                                    }"""
+                                    ))),
+                    @ApiResponse(responseCode = "404",
+                            description = "NOT_FOUND_MEMBER",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "errorCode": "NOT_FOUND_MEMBER",
+                                                      "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                                                    }"""
+                                    )))
+            }
+    )
+    @PatchMapping("/preparation-time")
+    PreparationTimeResponse updatePreparationTime(@RequestAttribute("memberId") Long memberId,
+                                                  @RequestBody UpdatePreparationTimeRequest request);
 }

--- a/src/main/java/com/dh/ondot/member/application/MemberFacade.java
+++ b/src/main/java/com/dh/ondot/member/application/MemberFacade.java
@@ -96,4 +96,8 @@ public class MemberFacade {
 
         return address;
     }
+
+    public Member updatePreparationTime(Long memberId, Integer preparationTime) {
+        return memberService.updatePreparationTime(memberId, preparationTime);
+    }
 }

--- a/src/main/java/com/dh/ondot/member/domain/Member.java
+++ b/src/main/java/com/dh/ondot/member/domain/Member.java
@@ -93,6 +93,10 @@ public class Member extends BaseTimeEntity {
         this.mapProvider = MapProvider.from(mapProvider);
     }
 
+    public void updatePreparationTime(Integer preparationTime) {
+        this.preparationTime = preparationTime;
+    }
+
     public boolean isNewMember() {
         return preparationTime == null;
     }

--- a/src/main/java/com/dh/ondot/member/domain/service/MemberService.java
+++ b/src/main/java/com/dh/ondot/member/domain/service/MemberService.java
@@ -17,4 +17,11 @@ public class MemberService {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundMemberException(memberId));
     }
+
+    @Transactional
+    public Member updatePreparationTime(Long memberId, Integer preparationTime) {
+        Member member = getMemberIfExists(memberId);
+        member.updatePreparationTime(preparationTime);
+        return member;
+    }
 }

--- a/src/main/java/com/dh/ondot/member/infra/jwt/AppleJwtUtil.java
+++ b/src/main/java/com/dh/ondot/member/infra/jwt/AppleJwtUtil.java
@@ -9,6 +9,7 @@ import com.dh.ondot.member.core.exception.OauthUserFetchFailedException;
 import com.dh.ondot.member.domain.enums.OauthProvider;
 import com.dh.ondot.member.domain.dto.UserInfo;
 import com.dh.ondot.member.infra.dto.ApplePublicKeyResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -91,7 +92,7 @@ public class AppleJwtUtil {
             // id_token 헤더 파싱 (kid, alg)
             String[] tokenParts = idToken.split("\\.");
             String headerJson = new String(Base64.getUrlDecoder().decode(tokenParts[0]));
-            Map<String, String> headerMap = objectMapper.readValue(headerJson, Map.class);
+            Map<String, String> headerMap = objectMapper.readValue(headerJson, new TypeReference<Map<String, String>>() {});
 
             // kid, alg에 맞는 PublicKey 찾기
             ApplePublicKeyResponse.Key matchedKey = appleKeys

--- a/src/main/java/com/dh/ondot/schedule/infra/outbox/OutboxMessage.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/outbox/OutboxMessage.java
@@ -32,6 +32,7 @@ public class OutboxMessage extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MessageStatus status;
 
+    @Builder.Default
     @Column(nullable = false)
     private int tryCount = 0;
 

--- a/src/test/java/com/dh/ondot/member/domain/service/MemberServiceTest.java
+++ b/src/test/java/com/dh/ondot/member/domain/service/MemberServiceTest.java
@@ -1,0 +1,96 @@
+package com.dh.ondot.member.domain.service;
+
+import com.dh.ondot.member.core.exception.NotFoundMemberException;
+import com.dh.ondot.member.domain.Member;
+import com.dh.ondot.member.domain.enums.OauthProvider;
+import com.dh.ondot.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberService 테스트")
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원 ID로 회원을 조회한다")
+    void getMemberIfExists_ValidId_ReturnsMember() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.registerWithOauth("test@example.com", OauthProvider.KAKAO, "kakao123");
+        
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        Member result = memberService.getMemberIfExists(memberId);
+
+        // then
+        assertThat(result).isEqualTo(member);
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 ID로 조회 시 예외가 발생한다")
+    void getMemberIfExists_InvalidId_ThrowsException() {
+        // given
+        Long memberId = 999L;
+        
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getMemberIfExists(memberId))
+                .isInstanceOf(NotFoundMemberException.class);
+        
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("회원의 준비 시간을 업데이트한다")
+    void updatePreparationTime_ValidInput_UpdatesSuccessfully() {
+        // given
+        Long memberId = 1L;
+        Integer newPreparationTime = 45;
+        Member member = Member.registerWithOauth("test@example.com", OauthProvider.KAKAO, "kakao123");
+        
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        Member result = memberService.updatePreparationTime(memberId, newPreparationTime);
+
+        // then
+        assertThat(result.getPreparationTime()).isEqualTo(newPreparationTime);
+        verify(memberRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 준비 시간 업데이트 시 예외가 발생한다")
+    void updatePreparationTime_InvalidMemberId_ThrowsException() {
+        // given
+        Long memberId = 999L;
+        Integer newPreparationTime = 45;
+        
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updatePreparationTime(memberId, newPreparationTime))
+                .isInstanceOf(NotFoundMemberException.class);
+        
+        verify(memberRepository).findById(memberId);
+    }
+}


### PR DESCRIPTION
## Issue Number
#49 

## As-Is
<!-- Describe the current issue or problem -->
* 회원 도메인(`Member`)에는 `preparationTime`을 온보딩 시에만 설정할 수 있었음
* 준비 시간을 조회하거나 수정할 수 있는 API가 존재하지 않았음
* `MemberController`, `MemberFacade`, `MemberService`에 준비 시간 관련 기능이 없음
* Swagger 명세에도 준비 시간 조회/수정 항목이 누락되어 있었음
* `tryCount`의 기본값이 명확히 `Builder` 단계에 드러나 있지 않아 혼동 가능성 존재
* `AppleJwtUtil`에서 JWT 헤더 파싱 시 `Map.class` 사용으로 타입 안정성이 떨어졌음


## To-Be
<!-- Describe the intended changes or improvements -->
* `Member` 도메인에 `updatePreparationTime()` 메서드를 추가해 준비 시간 단일 수정 가능하도록 개선
* `MemberController`, `MemberFacade`, `MemberService`에 `/preparation-time` GET/PATCH API 추가
* `PreparationTimeResponse`, `UpdatePreparationTimeRequest` 클래스 구현
* `MemberServiceTest`에 준비 시간 관련 테스트 2건 추가 (정상/예외 케이스)
* `MemberSwagger`에 준비 시간 관련 Swagger 명세 문서 추가
* `OutboxMessage`에서 `tryCount`에 `@Builder.Default` 적용으로 의도 명시
* `AppleJwtUtil`의 JWT 헤더 파싱 로직에 `TypeReference<Map<String, String>>` 적용하여 타입 안정성 확보


## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원 준비 시간 조회/수정 API 추가. 입력 값은 1~240분으로 검증되며, 응답에 최근 업데이트 시각을 포함합니다.
- 문서화
  - Swagger에 준비 시간 엔드포인트와 성공/오류 응답 예시를 추가했습니다.
- 테스트
  - 서비스 단위 테스트를 보강해 조회 실패 및 준비 시간 업데이트 시나리오를 검증했습니다.
- 기타
  - 내부 직렬화 타입 안정성 및 기본값 처리 개선으로 전반적 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->