### PR TITLE
[FEAT] 사용자 가입 이벤트 기반 Discord 알림 기능

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,9 @@ jobs:
           mkdir -p src/main/resources/auth
           echo "${{ secrets.APPLE_PRIVATE_KEY_FILE }}" > src/main/resources/auth/ApplePrivateKey.p8
 
-      # 4) Gradle 빌드 (테스트 제외)
+      # 4) Gradle 빌드
       - name: Build with Gradle
-        run: ./gradlew build -x test -DPROD_SERVER_URL=${{ secrets.PROD_SERVER_URL }} -Pspring.profiles.active=prod
+        run: ./gradlew build -DPROD_SERVER_URL=${{ secrets.PROD_SERVER_URL }} -Pspring.profiles.active=prod
 
       # ✨ 5) QEMU & Buildx 세팅 (멀티 아키텍처 빌드용)
       - name: Set up QEMU

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,8 @@ jobs:
               -e SAFETY_DATA_SERVICE_KEY=${{ secrets.SAFETY_DATA_SERVICE_KEY }} \
               -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
               -e PROD_SERVER_URL=${{ secrets.PROD_SERVER_URL }} \
+              -e DISCORD_WEBHOOK_ID=${{ secrets.DISCORD_WEBHOOK_ID }} \
+              -e DISCORD_WEBHOOK_TOKEN=${{ secrets.DISCORD_WEBHOOK_TOKEN }} \
               --name ${{ secrets.DOCKER_REPOSITORY }} \
               ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
             

--- a/src/main/java/com/dh/ondot/core/config/AsyncConstants.java
+++ b/src/main/java/com/dh/ondot/core/config/AsyncConstants.java
@@ -2,4 +2,5 @@ package com.dh.ondot.core.config;
 
 public interface AsyncConstants {
     String EVENT_ASYNC_TASK_EXECUTOR = "eventAsyncExecutor";
+    String DISCORD_ASYNC_TASK_EXECUTOR = "discordAsyncExecutor";
 }

--- a/src/main/java/com/dh/ondot/core/config/AsyncProperties.java
+++ b/src/main/java/com/dh/ondot/core/config/AsyncProperties.java
@@ -1,0 +1,28 @@
+package com.dh.ondot.core.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "async")
+public class AsyncProperties {
+    
+    private final EventConfig event = new EventConfig();
+    private final DiscordConfig discord = new DiscordConfig();
+
+    @Data
+    public static class EventConfig {
+        private int corePoolSize = 4;
+        private int maxPoolSize = 8;
+        private int queueCapacity = 500;
+    }
+
+    @Data
+    public static class DiscordConfig {
+        private int corePoolSize = 2;
+        private int maxPoolSize = 4;
+        private int queueCapacity = 100;
+    }
+}

--- a/src/main/java/com/dh/ondot/core/config/RestClientConfig.java
+++ b/src/main/java/com/dh/ondot/core/config/RestClientConfig.java
@@ -1,19 +1,27 @@
 package com.dh.ondot.core.config;
 
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
 
 @Configuration
 public class RestClientConfig {
 
     @Bean
     public RestClient restClient() {
-        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-        factory.setConnectTimeout(3000);
-        factory.setReadTimeout(1000);
-        
+        ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.defaults()
+                .withConnectTimeout(Duration.ofSeconds(3))
+                .withReadTimeout(Duration.ofSeconds(1));
+
+        ClientHttpRequestFactory factory = ClientHttpRequestFactoryBuilder
+                .detect()
+                .build(settings);
+
         return RestClient.builder()
                 .requestFactory(factory)
                 .build();

--- a/src/main/java/com/dh/ondot/core/config/RestClientConfig.java
+++ b/src/main/java/com/dh/ondot/core/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package com.dh.ondot.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(1000);
+        
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/com/dh/ondot/member/domain/event/UserRegistrationEvent.java
+++ b/src/main/java/com/dh/ondot/member/domain/event/UserRegistrationEvent.java
@@ -1,0 +1,11 @@
+package com.dh.ondot.member.domain.event;
+
+import com.dh.ondot.member.domain.enums.OauthProvider;
+
+public record UserRegistrationEvent(
+        Long memberId,
+        String email,
+        OauthProvider oauthProvider,
+        Long totalMemberCount
+) {
+}

--- a/src/main/java/com/dh/ondot/member/domain/service/MemberService.java
+++ b/src/main/java/com/dh/ondot/member/domain/service/MemberService.java
@@ -30,6 +30,10 @@ public class MemberService {
         return member;
     }
 
+    public Long getTotalMemberCount() {
+        return memberRepository.count();
+    }
+
     @Transactional
     public Member findOrRegisterOauthMember(UserInfo userInfo, OauthProvider oauthProvider) {
         return memberRepository.findByOauthInfo(userInfo.oauthProviderId(), oauthProvider)

--- a/src/main/java/com/dh/ondot/notification/infra/discord/DiscordMessageTemplate.java
+++ b/src/main/java/com/dh/ondot/notification/infra/discord/DiscordMessageTemplate.java
@@ -8,17 +8,26 @@ public class DiscordMessageTemplate {
     public String createUserRegistrationMessage(String memberEmail, OauthProvider oauthProvider, Long totalMemberCount) {
         return String.format(
                 """
-                    🎉 **온닷 %,d번 째 신규 사용자 가입!** 🎉
+                    🎉 **온닷 %,d번째 신규 사용자 가입 완료!** 🎉
             
                     👤 **사용자 계정**: %s
                     🔐 **가입 방식**: %s
                     👥 **총 사용자 수**: %,d명
                 """,
                 totalMemberCount,
-                memberEmail,
+                sanitizeEmail(memberEmail),
                 getOauthProviderDisplayName(oauthProvider),
                 totalMemberCount
         );
+    }
+
+    private String sanitizeEmail(String email) {
+        if (email == null || email.isEmpty()) {
+            return email;
+        }
+        
+        int atIndex = email.indexOf('@');
+        return atIndex > 0 ? email.substring(0, atIndex) : email;
     }
 
     private String getOauthProviderDisplayName(OauthProvider provider) {

--- a/src/main/java/com/dh/ondot/notification/infra/discord/DiscordMessageTemplate.java
+++ b/src/main/java/com/dh/ondot/notification/infra/discord/DiscordMessageTemplate.java
@@ -1,0 +1,31 @@
+package com.dh.ondot.notification.infra.discord;
+
+import com.dh.ondot.member.domain.enums.OauthProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiscordMessageTemplate {
+    public String createUserRegistrationMessage(String memberEmail, OauthProvider oauthProvider, Long totalMemberCount) {
+        return String.format(
+                """
+                    🎉 **온닷 %,d번 째 신규 사용자 가입!** 🎉
+            
+                    👤 **사용자 계정**: %s
+                    🔐 **가입 방식**: %s
+                    👥 **총 사용자 수**: %,d명
+                """,
+                totalMemberCount,
+                memberEmail,
+                getOauthProviderDisplayName(oauthProvider),
+                totalMemberCount
+        );
+    }
+
+    private String getOauthProviderDisplayName(OauthProvider provider) {
+        return switch (provider) {
+            case KAKAO -> "Kakao";
+            case APPLE -> "Apple";
+            default -> provider.name();
+        };
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/infra/discord/DiscordWebhookClient.java
+++ b/src/main/java/com/dh/ondot/notification/infra/discord/DiscordWebhookClient.java
@@ -1,0 +1,35 @@
+package com.dh.ondot.notification.infra.discord;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordWebhookClient {
+    private final RestClient restClient;
+
+    @Value("${external-api.discord.webhook.url}")
+    private String discordUrl;
+
+    public void sendMessage(String message) {
+        Map<String, Object> payload = createPayload(message);
+
+        restClient.post()
+                .uri(discordUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    private Map<String, Object> createPayload(String message) {
+        return Map.of("content", message);
+    }
+}

--- a/src/main/java/com/dh/ondot/notification/infra/discord/UserRegistrationEventListener.java
+++ b/src/main/java/com/dh/ondot/notification/infra/discord/UserRegistrationEventListener.java
@@ -1,0 +1,35 @@
+package com.dh.ondot.notification.infra.discord;
+
+import com.dh.ondot.member.domain.event.UserRegistrationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static com.dh.ondot.core.config.AsyncConstants.DISCORD_ASYNC_TASK_EXECUTOR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRegistrationEventListener {
+    private final DiscordWebhookClient discordWebhookClient;
+    private final DiscordMessageTemplate discordMessageTemplate;
+
+    @Async(DISCORD_ASYNC_TASK_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserRegistration(UserRegistrationEvent event) {
+        try {
+            String message = discordMessageTemplate.createUserRegistrationMessage(
+                event.email(),
+                event.oauthProvider(),
+                event.totalMemberCount()
+            );
+            
+            discordWebhookClient.sendMessage(message);
+        } catch (Exception e) {
+            log.error("[DISCORD FAIL] 회원 가입 완료 디스코드 메시지를 전송하는데 실패했습니다.[ memberId={} ]", event.memberId(), e);
+        }
+    }
+}

--- a/src/main/java/com/dh/ondot/schedule/infra/outbox/OutboxRetryScheduler.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/outbox/OutboxRetryScheduler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class OutboxRetryScheduler {
     private final OutboxBatchDispatcher dispatcher;
 
-    @Scheduled(fixedDelay = 60_000)
+//    @Scheduled(fixedDelay = 60_000)
     public void processPendingOutboxMessages() {
         dispatcher.dispatchRetryBatch();
         dispatcher.dispatchPendingBatch();

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -42,9 +42,13 @@ spring:
 
 async:
   event:
-    core-pool-size: 4
-    max-pool-size: 8
-    queue-capacity: 500
+    core-pool-size: 2
+    max-pool-size: 4
+    queue-capacity: 100
+  discord:
+    core-pool-size: 2
+    max-pool-size: 4
+    queue-capacity: 100
 
 oauth2:
   client:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -83,6 +83,9 @@ external-api:
   safety-data:
     base-url: https://www.safetydata.go.kr//V2/api/DSSP-IF-00247
     service-key: ${SAFETY_DATA_SERVICE_KEY}
+  discord:
+    webhook:
+      url: https://discord.com/api/webhooks/${DISCORD_WEBHOOK_ID}/${DISCORD_WEBHOOK_TOKEN}
 
 management:
   endpoints:

--- a/src/test/java/com/dh/ondot/schedule/domain/ScheduleTest.java
+++ b/src/test/java/com/dh/ondot/schedule/domain/ScheduleTest.java
@@ -47,7 +47,7 @@ class ScheduleTest {
     @DisplayName("일회성 스케줄의 가장 빠른 알람 시간을 계산한다")
     void calculateEarliestAlarmAt_OneTimeSchedule_ReturnsEarliestTime() {
         // given
-        LocalDateTime futureTime = LocalDateTime.now().plusHours(2);
+        LocalDateTime futureTime = LocalDateTime.of(2025, 12, 15, 18, 0);
         Schedule schedule = ScheduleFixture.builder()
                 .appointmentAt(futureTime)
                 .onlyPreparationAlarmEnabled()
@@ -121,8 +121,8 @@ class ScheduleTest {
     @DisplayName("약속 시간이 변경되었는지 확인한다")
     void isAppointmentTimeChanged_DifferentTime_ReturnsTrue() {
         // given
-        LocalDateTime originalTime = LocalDateTime.now().plusDays(1);
-        LocalDateTime newTime = LocalDateTime.now().plusDays(2);
+        LocalDateTime originalTime = LocalDateTime.of(2025, 12, 16, 10, 0);
+        LocalDateTime newTime = LocalDateTime.of(2025, 12, 17, 10, 0);
         
         Schedule schedule = ScheduleFixture.builder()
                 .appointmentAt(originalTime)
@@ -139,7 +139,7 @@ class ScheduleTest {
     @DisplayName("약속 시간이 같으면 false를 반환한다")
     void isAppointmentTimeChanged_SameTime_ReturnsFalse() {
         // given
-        LocalDateTime appointmentTime = LocalDateTime.now().plusDays(1);
+        LocalDateTime appointmentTime = LocalDateTime.of(2025, 12, 16, 10, 0);
         
         Schedule schedule = ScheduleFixture.builder()
                 .appointmentAt(appointmentTime)
@@ -160,7 +160,7 @@ class ScheduleTest {
         String newTitle = "변경된 제목";
         boolean newIsRepeat = true;
         SortedSet<Integer> newRepeatDays = ScheduleFixture.weekends();
-        LocalDateTime newAppointmentAt = LocalDateTime.now().plusDays(3);
+        LocalDateTime newAppointmentAt = LocalDateTime.of(2025, 12, 18, 10, 0);
 
         // when
         schedule.updateCore(newTitle, newIsRepeat, newRepeatDays, newAppointmentAt);
@@ -177,7 +177,7 @@ class ScheduleTest {
         // given
         Schedule schedule = ScheduleFixture.repeatSchedule(ScheduleFixture.weekdays());
         String newTitle = "일회성 스케줄";
-        LocalDateTime newAppointmentAt = LocalDateTime.now().plusDays(1);
+        LocalDateTime newAppointmentAt = LocalDateTime.of(2025, 12, 16, 10, 0);
 
         // when
         schedule.updateCore(newTitle, false, null, newAppointmentAt);
@@ -193,7 +193,7 @@ class ScheduleTest {
         // given
         Schedule schedule = ScheduleFixture.defaultSchedule();
         Long memberId = 999L;
-        LocalDateTime appointmentAt = LocalDateTime.now().plusHours(3);
+        LocalDateTime appointmentAt = LocalDateTime.of(2025, 12, 15, 19, 0);
 
         // when
         schedule.setupQuickSchedule(memberId, appointmentAt);

--- a/src/test/java/com/dh/ondot/schedule/fixture/AlarmFixture.java
+++ b/src/test/java/com/dh/ondot/schedule/fixture/AlarmFixture.java
@@ -11,15 +11,15 @@ import java.time.LocalDateTime;
 public class AlarmFixture {
 
     public static Alarm defaultPreparationAlarm() {
-        return enabledAlarm(LocalDateTime.now().plusHours(1));
+        return enabledAlarm(LocalDateTime.of(2025, 12, 15, 15, 0)); // 1시간 전
     }
 
     public static Alarm defaultDepartureAlarm() {
-        return enabledAlarm(LocalDateTime.now().plusMinutes(90));
+        return enabledAlarm(LocalDateTime.of(2025, 12, 15, 15, 30)); // 30분 전
     }
 
     public static Alarm enabledAlarm() {
-        return enabledAlarm(LocalDateTime.now().plusHours(1));
+        return enabledAlarm(LocalDateTime.of(2025, 12, 15, 15, 0));
     }
 
     public static Alarm enabledAlarm(LocalDateTime triggeredAt) {
@@ -33,7 +33,7 @@ public class AlarmFixture {
     }
 
     public static Alarm disabledAlarm() {
-        return disabledAlarm(LocalDateTime.now().plusHours(1));
+        return disabledAlarm(LocalDateTime.of(2025, 12, 15, 15, 0));
     }
 
     public static Alarm disabledAlarm(LocalDateTime triggeredAt) {

--- a/src/test/java/com/dh/ondot/schedule/fixture/ScheduleFixture.java
+++ b/src/test/java/com/dh/ondot/schedule/fixture/ScheduleFixture.java
@@ -30,7 +30,7 @@ public class ScheduleFixture {
         private String title = "테스트 일정";
         private Boolean isRepeat = false;
         private SortedSet<Integer> repeatDays = null;
-        private LocalDateTime appointmentAt = LocalDateTime.now().plusHours(2);
+        private LocalDateTime appointmentAt = LocalDateTime.of(2025, 12, 15, 16, 0);
         private Boolean isMedicationRequired = false;
         private String preparationNote = "준비 메모";
         private Place departurePlace = PlaceFixture.defaultDeparturePlace();
@@ -65,14 +65,14 @@ public class ScheduleFixture {
         }
 
         public ScheduleBuilder onlyPreparationAlarmEnabled() {
-            this.preparationAlarm = AlarmFixture.enabledAlarm();
+            this.preparationAlarm = AlarmFixture.enabledAlarm(this.appointmentAt.minusHours(1));
             this.departureAlarm = AlarmFixture.disabledAlarm();
             return this;
         }
 
         public ScheduleBuilder onlyDepartureAlarmEnabled() {
             this.preparationAlarm = AlarmFixture.disabledAlarm();
-            this.departureAlarm = AlarmFixture.enabledAlarm();
+            this.departureAlarm = AlarmFixture.enabledAlarm(this.appointmentAt.minusMinutes(30));
             return this;
         }
 


### PR DESCRIPTION
## Issue Number
#56 

## As-Is
<!-- Describe the current issue or problem -->
- Discord로 사용자 가입 알림을 보내는 기능이 존재하지 않음
- 사용자 가입 후 발생하는 이벤트 전파 체계 미흡
- @Async 실행자 설정이 고정값이며, 유형별 분리 불가능
- GitHub Actions에서 Discord Webhook 정보를 사용하지 않음

## To-Be
<!-- Describe the intended changes or improvements -->
- 사용자 가입 시 UserRegistrationEvent 를 발행하여 이벤트 기반 아키텍처 도입
- UserRegistrationEventListener 를 통해 Discord로 비동기 알림 메시지 전송 구현
- 알림 메시지는 DiscordMessageTemplate 에서 생성하며 텍스트 블록 기반 포맷 적용
- DiscordWebhookClient 를 통해 Discord Webhook URL로 POST 요청 수행
- AsyncConstants 및 AsyncConfig, AsyncProperties 구조를 도입하여 event / discord 용 TaskExecutor 분리
- GitHub Actions 배포 파이프라인에 Discord Webhook 관련 환경변수 주입 로직 추가

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원 가입 완료 시 Discord 채널로 알림을 전송합니다.
- 리팩터
  - 비동기 실행기 구성을 정리하고 전용 실행기 추가로 안정성을 개선했습니다.
- 작업
  - CI에서 테스트 실행을 활성화했습니다.
  - 프로덕션 배포 시 Discord 웹훅 환경 변수를 추가로 전달합니다.
  - 일부 백그라운드 재시도 스케줄러를 일시 비활성화했습니다.
- 테스트
  - 사용량 한도 관련 테스트를 동시성/재시도 시나리오로 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->