### PR TITLE
[REFACTOR] 반복 알람의 경우 현재 시점 기준으로 울리는 시간 반환

### DIFF
--- a/src/main/java/com/dh/ondot/schedule/api/response/AlarmDto.java
+++ b/src/main/java/com/dh/ondot/schedule/api/response/AlarmDto.java
@@ -2,6 +2,7 @@ package com.dh.ondot.schedule.api.response;
 
 import com.dh.ondot.core.util.TimeUtils;
 import com.dh.ondot.schedule.domain.Alarm;
+import com.dh.ondot.schedule.domain.Schedule;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +24,21 @@ public record AlarmDto(
                 alarm.getMode().name(),
                 alarm.isEnabled(),
                 TimeUtils.toSeoulDateTime(alarm.getTriggeredAt()),
+                alarm.getSnooze().isSnoozeEnabled(),
+                alarm.getSnooze().getSnoozeInterval().getValue(),
+                alarm.getSnooze().getSnoozeCount().getValue(),
+                alarm.getSound().getSoundCategory().name(),
+                alarm.getSound().getRingTone().name(),
+                alarm.getSound().getVolume()
+        );
+    }
+
+    public static AlarmDto of(Alarm alarm, Schedule schedule) {
+        return new AlarmDto(
+                alarm.getId(),
+                alarm.getMode().name(),
+                alarm.isEnabled(),
+                TimeUtils.toSeoulDateTime(schedule.getNextRepeatAlarmTime(alarm.getTriggeredAt())),
                 alarm.getSnooze().isSnoozeEnabled(),
                 alarm.getSnooze().getSnoozeInterval().getValue(),
                 alarm.getSnooze().getSnoozeCount().getValue(),

--- a/src/main/java/com/dh/ondot/schedule/application/dto/HomeScheduleListItem.java
+++ b/src/main/java/com/dh/ondot/schedule/application/dto/HomeScheduleListItem.java
@@ -32,8 +32,8 @@ public record HomeScheduleListItem(
                 schedule.getIsRepeat(),
                 schedule.getRepeatDays() == null ? List.of() : List.copyOf(schedule.getRepeatDays()),
                 TimeUtils.toSeoulDateTime(schedule.getAppointmentAt()),
-                AlarmDto.of(schedule.getPreparationAlarm()),
-                AlarmDto.of(schedule.getDepartureAlarm()),
+                AlarmDto.of(schedule.getPreparationAlarm(), schedule),
+                AlarmDto.of(schedule.getDepartureAlarm(), schedule),
                 schedule.hasAnyActiveAlarm()
         );
     }

--- a/src/main/java/com/dh/ondot/schedule/application/mapper/HomeScheduleListItemMapper.java
+++ b/src/main/java/com/dh/ondot/schedule/application/mapper/HomeScheduleListItemMapper.java
@@ -1,9 +1,6 @@
 package com.dh.ondot.schedule.application.mapper;
 
-import com.dh.ondot.core.util.TimeUtils;
-import com.dh.ondot.schedule.api.response.AlarmDto;
 import com.dh.ondot.schedule.application.dto.HomeScheduleListItem;
-import com.dh.ondot.schedule.domain.Place;
 import com.dh.ondot.schedule.domain.Schedule;
 import org.springframework.stereotype.Component;
 
@@ -15,30 +12,8 @@ public class HomeScheduleListItemMapper {
 
     public List<HomeScheduleListItem> toListOrderedByAppointmentAt(List<Schedule> schedules) {
         return schedules.stream()
-                .map(this::toHomeScheduleItem)
+                .map(HomeScheduleListItem::from)
                 .sorted(Comparator.comparing(HomeScheduleListItem::appointmentAt))
                 .toList();
-    }
-
-    public HomeScheduleListItem toHomeScheduleItem(Schedule schedule) {
-        Place departurePlace = schedule.getDeparturePlace();
-        Place arrivalPlace = schedule.getArrivalPlace();
-
-        return new HomeScheduleListItem(
-                schedule.getId(),
-                departurePlace.getLongitude(),
-                departurePlace.getLatitude(),
-                arrivalPlace.getLongitude(),
-                arrivalPlace.getLatitude(),
-                schedule.getTitle(),
-                schedule.getIsRepeat(),
-                schedule.getRepeatDays() == null 
-                        ? List.of() 
-                        : List.copyOf(schedule.getRepeatDays()),
-                TimeUtils.toSeoulDateTime(schedule.getAppointmentAt()),
-                AlarmDto.of(schedule.getPreparationAlarm()),
-                AlarmDto.of(schedule.getDepartureAlarm()),
-                schedule.hasAnyActiveAlarm()
-        );
     }
 }

--- a/src/main/java/com/dh/ondot/schedule/core/EventSerializer.java
+++ b/src/main/java/com/dh/ondot/schedule/core/EventSerializer.java
@@ -1,4 +1,4 @@
-package com.dh.ondot.schedule.application.port;
+package com.dh.ondot.schedule.core;
 
 import com.dh.ondot.schedule.core.exception.SerializationException;
 

--- a/src/main/java/com/dh/ondot/schedule/core/JacksonEventSerializer.java
+++ b/src/main/java/com/dh/ondot/schedule/core/JacksonEventSerializer.java
@@ -1,6 +1,5 @@
-package com.dh.ondot.schedule.infra.serialization;
+package com.dh.ondot.schedule.core;
 
-import com.dh.ondot.schedule.application.port.EventSerializer;
 import com.dh.ondot.schedule.core.exception.SerializationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/dh/ondot/schedule/domain/Schedule.java
+++ b/src/main/java/com/dh/ondot/schedule/domain/Schedule.java
@@ -163,6 +163,13 @@ public class Schedule extends BaseTimeEntity {
         return TimeUtils.findEarliestAfterNow(nextPrepAlarmAt, nextDeptAlarmAt);
     }
 
+    public Instant getNextRepeatAlarmTime(Instant baseAlarmTime) {
+        if (!isRepeat) {
+            return baseAlarmTime;
+        }
+        return calculateNextRepeatTime(baseAlarmTime);
+    }
+
     /**
      * 반복 설정에 따라 다음 알람 시간을 계산한다.
      * 현재 시간 이후 7일 이내에서 해당 요일에 맞는 가장 빠른 시간을 찾는다.

--- a/src/main/java/com/dh/ondot/schedule/infra/event/ScheduleInternalEventRecordListener.java
+++ b/src/main/java/com/dh/ondot/schedule/infra/event/ScheduleInternalEventRecordListener.java
@@ -1,6 +1,6 @@
 package com.dh.ondot.schedule.infra.event;
 
-import com.dh.ondot.schedule.application.port.EventSerializer;
+import com.dh.ondot.schedule.core.EventSerializer;
 import com.dh.ondot.schedule.domain.event.QuickScheduleRequestedEvent;
 import com.dh.ondot.schedule.infra.outbox.OutboxMessage;
 import com.dh.ondot.schedule.infra.outbox.OutboxMessageRepository;

--- a/src/test/java/com/dh/ondot/schedule/domain/service/ScheduleServiceTest.java
+++ b/src/test/java/com/dh/ondot/schedule/domain/service/ScheduleServiceTest.java
@@ -151,33 +151,6 @@ class ScheduleServiceTest {
     }
 
     @Test
-    @DisplayName("반복 일정이 포함된 경우에도 가장 빠른 알람 시간을 반환한다")
-    void getEarliestActiveAlarmAt_WithRepeatSchedules_ReturnsEarliest() {
-        // given
-        Schedule oneTimeSchedule = ScheduleFixture.builder()
-                .appointmentAt(LocalDateTime.of(2025, 9, 4, 8, 0)) // 더 이른 시간
-                .onlyPreparationAlarmEnabled()
-                .build();
-                
-        Schedule repeatSchedule = ScheduleFixture.builder()
-                .isRepeat(true)
-                .repeatDays(ScheduleFixture.weekdays()) // 평일 반복
-                .appointmentAt(LocalDateTime.of(2025, 9, 15, 10, 0)) // 기준 시간
-                .onlyDepartureAlarmEnabled()
-                .build();
-        
-        List<Schedule> schedules = List.of(oneTimeSchedule, repeatSchedule);
-
-        // when
-        Instant result = scheduleService.getEarliestActiveAlarmAt(schedules);
-
-        // then
-        // 일회성 스케줄의 알람이 반복 스케줄보다 빨라야 함
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(oneTimeSchedule.getPreparationAlarm().getTriggeredAt());
-    }
-
-    @Test
     @DisplayName("스케줄을 저장한다")
     void saveSchedule_ValidSchedule_SavesSuccessfully() {
         // given


### PR DESCRIPTION
## Issue Number
#58 

## As-Is

* `AlarmDto`는 `Alarm` 객체만을 기반으로 생성되며, `triggeredAt` 시간은 고정된 `Alarm.triggeredAt` 값만 사용함
* 반복 알람(`isRepeat = true`)의 경우, 다음 알람이 언제 울릴지 사용자에게 정확히 전달되지 않음
* `HomeScheduleListItem.from(Schedule)` 내부에서도 `AlarmDto.of(alarm)`을 사용하여 반복 알람의 정확한 울림 시간이 반영되지 않음

## To-Be

* `AlarmDto.of(Alarm, Schedule)` 오버로드 메서드 추가
  → 반복 알람의 경우 `Schedule.getNextRepeatAlarmTime(alarm.getTriggeredAt())`을 사용하여 **현재 시점을 기준으로 계산된 다음 울림 시간**을 `triggeredAt`에 설정
* `HomeScheduleListItem.from(Schedule)` 에서 `AlarmDto.of(alarm, schedule)`을 사용하도록 변경
  → 반복 알람의 경우도 사용자에게 정확한 다음 알림 시간이 노출되도록 개선

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능/개선
  - 반복 일정의 알림 시간이 실제 다음 울림 시각으로 계산되어 홈 스케줄 목록 등에서 더 정확하게 표시됩니다(준비/출발 알림 모두 적용).
- 버그 수정
  - 일부 상황에서 반복 일정 알림이 기준 시간으로 표시될 수 있던 문제를 교정했습니다.
- 리팩터
  - 홈 스케줄 매핑 로직을 단순화하고 직렬화 구성 요소의 패키지를 정리했습니다. 사용자 기능 변화는 없습니다.
- 테스트
  - 단일/반복 일정 혼재 시나리오 관련 일부 테스트를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->